### PR TITLE
Implements #46: Filtering Exercises

### DIFF
--- a/app/src/main/java/com/easyfitness/DAO/DAOMachine.java
+++ b/app/src/main/java/com/easyfitness/DAO/DAOMachine.java
@@ -175,6 +175,20 @@ public class DAOMachine extends DAOBase {
         return getMachineListCursor(selectQuery);
     }
 
+
+    /**
+     * @return List of Machine object ordered by Favorite and Name
+     */
+    public Cursor getFilteredMachines(CharSequence filterString) {
+        // Select All Query
+        // like '%"+inputText+"%'";
+        String selectQuery = "SELECT  * FROM " + TABLE_NAME + " WHERE " + NAME + " LIKE " + "'%" + filterString + "%' "  + " ORDER BY "
+                + FAVORITES + " DESC," + NAME + " ASC";
+
+        // return value list
+        return getMachineListCursor(selectQuery);
+    }
+
     /**
      * @return List of Machine object ordered by Favorite and Name
      */

--- a/app/src/main/java/com/easyfitness/fonte/FontesFragment.java
+++ b/app/src/main/java/com/easyfitness/fonte/FontesFragment.java
@@ -380,7 +380,7 @@ public class FontesFragment extends Fragment {
 						break;
 					// Edit
 					case 1:
-						Toast.makeText(getActivity(), R.string.edit_soon_available, Toast.LENGTH_SHORT).show();
+						Toast.makeText(getActivity(), R.string.soon_available, Toast.LENGTH_SHORT).show();
 						break;
 					// Share
 					case 2:

--- a/app/src/main/java/com/easyfitness/machines/MachineCursorAdapter.java
+++ b/app/src/main/java/com/easyfitness/machines/MachineCursorAdapter.java
@@ -6,6 +6,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CursorAdapter;
+import android.widget.Filterable;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -15,7 +16,7 @@ import com.easyfitness.R;
 import com.easyfitness.utils.ImageUtil;
 import com.github.ivbaranov.mfb.MaterialFavoriteButton;
 
-public class MachineCursorAdapter extends CursorAdapter {
+public class MachineCursorAdapter extends CursorAdapter implements Filterable {
 	 
 	 private LayoutInflater mInflater;
 	 private Context mContext = null;

--- a/app/src/main/java/com/easyfitness/machines/MachineFragment.java
+++ b/app/src/main/java/com/easyfitness/machines/MachineFragment.java
@@ -111,9 +111,6 @@ public class MachineFragment extends Fragment {
             if(charSequence.length()==0) {
                 mTableAdapter.notifyDataSetChanged();
                 mTableAdapter = ((MachineCursorAdapter)machineList.getAdapter());
-                c = mDbMachine.getAllMachines();
-                oldCursor = mTableAdapter.swapCursor(c);
-                if (oldCursor!=null) oldCursor.close();
 
             }
             else{

--- a/app/src/main/java/com/easyfitness/machines/MachineFragment.java
+++ b/app/src/main/java/com/easyfitness/machines/MachineFragment.java
@@ -105,20 +105,14 @@ public class MachineFragment extends Fragment {
         @Override
         public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
 
-            Cursor c;
-            Cursor oldCursor;
-
             if(charSequence.length()==0) {
                 mTableAdapter.notifyDataSetChanged();
                 mTableAdapter = ((MachineCursorAdapter)machineList.getAdapter());
-
             }
             else{
                 mTableAdapter.getFilter().filter(charSequence);
                 mTableAdapter.notifyDataSetChanged();
-
             }
-
         }
 
         @Override

--- a/app/src/main/res/layout/tab_machine.xml
+++ b/app/src/main/res/layout/tab_machine.xml
@@ -12,36 +12,25 @@
     android:paddingTop="0dp"    >
 
 
-	<LinearLayout
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:orientation="vertical">
-
-
-		<Button
-			android:id="@+id/addExercise"
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"
-			android:layout_margin="8dp"
-			android:background="@android:color/white"
-			android:text="@string/AddLabel" />
-
-
-	</LinearLayout>
-
-    <RelativeLayout
-        android:layout_width="fill_parent"
+    <AutoCompleteTextView
+        android:id="@+id/searchField"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal" >
-    
+        android:layout_gravity="center_vertical"
+        android:hint="@string/MachineHint"
+        android:imeOptions="actionNext"
+        android:inputType="text|textCapWords|textAutoComplete|textNoSuggestions|textVisiblePassword"
+        android:nextFocusForward="@+id/editSerie"
+        android:singleLine="true" />
+
+
 	    <ListView
-	        android:id="@+id/listMachine"        
+	        android:id="@+id/listMachine"
 	        android:layout_width="match_parent"
 	        android:layout_height="match_parent"
 	        android:drawSelectorOnTop="false"
 	        android:minHeight="300dip" >
 	  	</ListView>
 
-    </RelativeLayout> 	
-    
+
 </LinearLayout>

--- a/app/src/main/res/menu/exercises_menu.xml
+++ b/app/src/main/res/menu/exercises_menu.xml
@@ -1,0 +1,53 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_chrono"
+        android:icon="@drawable/ic_chrono"
+        android:title="@string/ChronometerLabel"
+        app:showAsAction="always" />
+
+    <item
+        android:id="@+id/action_profil"
+        android:icon="@drawable/ic_profile_black"
+        android:title="Profil"
+        android:visible="false"
+        app:showAsAction="always">
+
+        <menu>
+            <item
+                android:id="@+id/create_newprofil"
+                android:title="@string/profil_create_new" />
+            <item
+                android:id="@+id/change_profil"
+                android:title="@string/profil_change" />
+            <item
+                android:id="@+id/rename_profil"
+                android:title="@string/renameProfilTitle" />
+            <item
+                android:id="@+id/delete_profil"
+                android:title="@string/profil_delete" />
+            <item
+                android:id="@+id/photo_profil"
+                android:title="Profile picture" />
+        </menu>
+    </item>
+
+
+    <item android:id="@+id/add_exercises"
+        android:title="@string/AddLabel"
+        app:showAsAction="never|withText"/>
+
+    <item android:id="@+id/export_exercises"
+        android:title="@string/export_exercises"
+        app:showAsAction="never|withText"/>
+
+    <item android:id="@+id/import_exercises"
+        android:title="@string/import_exercises"
+        app:showAsAction="never|withText"/>
+
+    <item android:id="@+id/action_apropos"
+        android:title="@string/AboutLabel"
+          app:showAsAction="never|withText"/>
+
+</menu>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -78,6 +78,8 @@
     <string name="SettingLabel">Einstellungen</string>
     <string name="menu_settings">Einstellungen</string>
     <string name="export_database">Aufzeichnungen exportieren</string>
+    <string name="export_exercises">Übungen exportieren</string>
+    <string name="import_exercises">Übungen importieren</string>
     <string name="export_question">Willst du die Datenbank exportieren ?</string>
     <string name="export_success">Datenbank exportiert</string>
     <string name="export_failed">Datenbank export fehlgeschlagen</string>
@@ -258,7 +260,7 @@
     <string name="reset">Reset</string>
     <string name="muscles">Muskeln</string>
     <string name="description">Beschreibung</string>
-    <string name="edit_soon_available">in Kürze verfügbar</string>
+    <string name="soon_available">In Kürze verfügbar</string>
     <string name="edit_value">Neue Wert</string>
 </resources>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -72,6 +72,8 @@
 	<string name="SettingLabel">Paramètres</string>
     <string name="menu_settings">Paramètres</string>
     <string name="export_database">Exporter la base de données</string>
+    <string name="export_exercises">Exporter les exercises</string>
+    <string name="import_exercises">Importer les exercises</string>
     <string name="export_question">Voulez-vous exporter la base de données?</string>
     <string name="export_success">Base de données exportée</string>
     <string name="export_failed">Erreur dans l\'export de la base de données</string>
@@ -244,7 +246,7 @@
     <string name="weight_missing">Merci de rentrer votre poids</string>
     <string name="profileEnterYourSize">Votre taille</string>
     <string name="profileEnterYourBirthday">Votre date de naissance</string>
-    <string name="edit_soon_available">Bientôt disponible</string>
+    <string name="soon_available">Bientôt disponible</string>
     <string name="name">Nom</string>
     <string name="ProfileLabel">Profil</string>
     <string name="profile_page">Details</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,8 @@
 	<string name="SettingLabel">Settings</string>
     <string name="menu_settings">Settings</string>
     <string name="export_database">Export Records</string>    
+    <string name="export_exercises">Export Exercises</string>
+    <string name="import_exercises">Import Exercises</string>
     <string name="export_question">Do you want to export database ?</string>
     <string name="export_success">Database exported</string>
     <string name="export_failed">Database export failed</string>
@@ -248,7 +250,7 @@
     <string name="max">Max</string>
     <string name="areyousure">Are you sure?</string>
     <string name="Take_profile_picture">Picture for profile</string>
-    <string name="edit_soon_available">Edit soon available</string>
+    <string name="soon_available">Soon available</string>
     <string name="name">Name</string>
     <string name="description">Description</string>
     <string name="muscles">Muscles</string>


### PR DESCRIPTION
First, I've cleaned the UI (`tab_machines.xml`):
The Add button is now found in the menu. For that I've overwrite the menu for the fragment. This was in fact an annoyance in the past for me: we have one global menu, but sometimes it makes more sense, that every fragment has its own menu. So in this case I've already added the unimplemented import and export buttons (because I want to import and export the exercises on its own as well). For that I've changed the String `soon_available` a bit in order that it can be used more generally.

In the UI there is now an `EditText` (in fact it is an `AutoCompleteTextView`) instead of the add button. It is used for the filtering. By the way most of the work was done in the `MachineFragment.java`.
I address the `EditText` in the code as `searchField` (maybe filterField would be better, but whatever).
The `searchField` has an `onTextChangeListener`, so at each key press the function `onTextChanged` is executed. In this function the adapter is modified. The line `mTableAdapter.getFilter().filter(charSequence);` forwards to `setFilterQueryProvider`, which in turn returns an Cursor for sql request. The sql request was done with the keyword `LIKE` and is similar to `getAllMachines` inside `DAOMachine.java`.

