### PR TITLE
Added an alternative app name for debug variant to make it distinguishable

### DIFF
--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name" translatable="false">Debug: Fast N Fitness</string>
+</resources>


### PR DESCRIPTION
Without it, the Play Store variant and the debug variant have the same name and
the same icon. Now the debug variant is at least different by name.

This should've been part of the `applicationIdSuffix` addition but I forgot it.