### PR TITLE
Removed auto-clear in machine name edit text

### DIFF
--- a/app/src/main/java/com/easyfitness/fonte/FontesFragment.java
+++ b/app/src/main/java/com/easyfitness/fonte/FontesFragment.java
@@ -453,6 +453,7 @@ public class FontesFragment extends Fragment {
             if (!workoutValuesInputView.isShowExerciseTypeSelector())
                 setCurrentMachine(machineEdit.getText().toString());
         }
+        updateMachineImage();
     };
 
     private void updateMachineImage() {

--- a/app/src/main/java/com/easyfitness/fonte/FontesFragment.java
+++ b/app/src/main/java/com/easyfitness/fonte/FontesFragment.java
@@ -439,26 +439,19 @@ public class FontesFragment extends Fragment {
     };
     private OnFocusChangeListener touchRazEdit = (v, hasFocus) -> {
         if (hasFocus) {
-            switch (v.getId()) {
-                case R.id.editMachine:
-                    updateMachineImage();
+            updateMachineImage();
 
-                    workoutValuesInputView.setWeightComment("");
-                    workoutValuesInputView.setShowExerciseTypeSelector(true);
-                    break;
-            }
+            workoutValuesInputView.setWeightComment("");
+            workoutValuesInputView.setShowExerciseTypeSelector(true);
+
             v.post(() -> {
                 InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
                 imm.showSoftInput(v, InputMethodManager.SHOW_IMPLICIT);
             });
-        } else if (!hasFocus) {
-            switch (v.getId()) {
-                case R.id.editMachine:
-                    // If a creation of a new machine is not ongoing.
-                    if (!workoutValuesInputView.isShowExerciseTypeSelector())
-                        setCurrentMachine(machineEdit.getText().toString());
-                    break;
-            }
+        } else {
+            // If a creation of a new machine is not ongoing.
+            if (!workoutValuesInputView.isShowExerciseTypeSelector())
+                setCurrentMachine(machineEdit.getText().toString());
         }
     };
 

--- a/app/src/main/java/com/easyfitness/fonte/FontesFragment.java
+++ b/app/src/main/java/com/easyfitness/fonte/FontesFragment.java
@@ -441,17 +441,7 @@ public class FontesFragment extends Fragment {
         if (hasFocus) {
             switch (v.getId()) {
                 case R.id.editMachine:
-                    switch (workoutValuesInputView.getSelectedType()) {
-                        case CARDIO:
-                            machineImage.setImageResource(R.drawable.ic_training_white_50dp);
-                            break;
-                        case ISOMETRIC:
-                            machineImage.setImageResource(R.drawable.ic_static);
-                            break;
-                        case STRENGTH:
-                        default:
-                            machineImage.setImageResource(R.drawable.ic_gym_bench_50dp);
-                    }
+                    updateMachineImage();
 
                     workoutValuesInputView.setWeightComment("");
                     workoutValuesInputView.setShowExerciseTypeSelector(true);
@@ -471,6 +461,21 @@ public class FontesFragment extends Fragment {
             }
         }
     };
+
+    private void updateMachineImage() {
+        switch (workoutValuesInputView.getSelectedType()) {
+            case CARDIO:
+                machineImage.setImageResource(R.drawable.ic_training_white_50dp);
+                break;
+            case ISOMETRIC:
+                machineImage.setImageResource(R.drawable.ic_static);
+                break;
+            case STRENGTH:
+            default:
+                machineImage.setImageResource(R.drawable.ic_gym_bench_50dp);
+        }
+    }
+
     private CompoundButton.OnCheckedChangeListener checkedAutoTimeCheckBox = (buttonView, isChecked) -> {
         dateEdit.setEnabled(!isChecked);
         timeEdit.setEnabled(!isChecked);
@@ -775,17 +780,7 @@ public class FontesFragment extends Fragment {
 
     private void setCurrentMachine(String machineStr) {
         if (machineStr.isEmpty()) {
-            switch (workoutValuesInputView.getSelectedType()) {
-                case CARDIO:
-                    machineImage.setImageResource(R.drawable.ic_training_white_50dp);
-                    break;
-                case ISOMETRIC:
-                    machineImage.setImageResource(R.drawable.ic_static);
-                    break;
-                case STRENGTH:
-                default:
-                    machineImage.setImageResource(R.drawable.ic_gym_bench_50dp);
-            }
+            updateMachineImage();
             machineImage.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
             // Default image
             workoutValuesInputView.setShowExerciseTypeSelector(true);

--- a/app/src/main/java/com/easyfitness/fonte/FontesFragment.java
+++ b/app/src/main/java/com/easyfitness/fonte/FontesFragment.java
@@ -441,7 +441,6 @@ public class FontesFragment extends Fragment {
         if (hasFocus) {
             switch (v.getId()) {
                 case R.id.editMachine:
-                    machineEdit.setText("");
                     switch (workoutValuesInputView.getSelectedType()) {
                         case CARDIO:
                             machineImage.setImageResource(R.drawable.ic_training_white_50dp);

--- a/app/src/main/res/layout/tab_fontes.xml
+++ b/app/src/main/res/layout/tab_fontes.xml
@@ -60,6 +60,7 @@
                         android:hint="@string/MachineHint"
                         android:imeOptions="actionNext"
                         android:inputType="text|textCapWords|textAutoComplete"
+                        android:selectAllOnFocus="true"
                         android:singleLine="true" />
 
                     <ImageButton


### PR DESCRIPTION
Replaced by select all on focus which mirrors the previos behavior best: a user can tap on the input and start typing, the text gets replaced completely. However, it is now possible to tap two times to place the cursor within the text.

Closes #154 