### PR TITLE
Timezone fixes

### DIFF
--- a/app/src/main/java/com/easyfitness/DAO/CVSManager.java
+++ b/app/src/main/java/com/easyfitness/DAO/CVSManager.java
@@ -135,7 +135,7 @@ public class CVSManager {
                 Date dateRecord = records.get(i).getDate();
 
                 csvOutputFonte.write(DateConverter.dateToDBDateStr(dateRecord));
-                csvOutputFonte.write(records.get(i).getTime());
+                csvOutputFonte.write(DateConverter.dateToDBTimeStr(dateRecord));
                 csvOutputFonte.write(records.get(i).getExercise());
                 csvOutputFonte.write(Integer.toString(ExerciseType.STRENGTH.ordinal()));
                 csvOutputFonte.write(Long.toString(records.get(i).getProfileId()));
@@ -321,8 +321,7 @@ public class CVSManager {
                 switch (csvRecords.get(TABLE_HEAD)) {
                     case DAORecord.TABLE_NAME: {
                         Date date;
-                        date = DateConverter.DBDateStrToDate(csvRecords.get(DAORecord.DATE));
-                        String time = csvRecords.get(DAORecord.TIME);
+                        date = DateConverter.DBDateTimeStrToDate(csvRecords.get(DAORecord.DATE), csvRecords.get(DAORecord.TIME));
                         String exercise = csvRecords.get(DAORecord.EXERCISE);
                         if ( dbcMachine.getMachine(exercise) != null ) {
                             long exerciseId = dbcMachine.getMachine(exercise).getId();
@@ -344,7 +343,7 @@ public class CVSManager {
                             }
                             String notes = csvRecords.get(DAORecord.NOTES);
 
-                            Record record = new Record(date, time, exercise, exerciseId, pProfile.getId(), serie, repetition, poids, unit, second, distance, distance_unit, duration, notes, exerciseType, -1);
+                            Record record = new Record(date, exercise, exerciseId, pProfile.getId(), serie, repetition, poids, unit, second, distance, distance_unit, duration, notes, exerciseType, -1);
                             recordsList.add(record);
                         } else {
                             return false;
@@ -362,7 +361,7 @@ public class CVSManager {
                         String exercice = csvRecords.get(DAOOldCardio.EXERCICE);
                         float distance = Float.valueOf(csvRecords.get(DAOOldCardio.DISTANCE));
                         int duration = Integer.valueOf(csvRecords.get(DAOOldCardio.DURATION));
-                        dbcCardio.addCardioRecord(date, "", exercice, distance, duration, pProfile.getId(), DistanceUnit.KM, -1);
+                        dbcCardio.addCardioRecord(date, exercice, distance, duration, pProfile.getId(), DistanceUnit.KM, -1);
                         dbcCardio.close();
 
                         break;

--- a/app/src/main/java/com/easyfitness/DAO/CVSManager.java
+++ b/app/src/main/java/com/easyfitness/DAO/CVSManager.java
@@ -134,8 +134,8 @@ public class CVSManager {
 
                 Date dateRecord = records.get(i).getDate();
 
-                csvOutputFonte.write(DateConverter.dateToDBDateStr(dateRecord));
-                csvOutputFonte.write(DateConverter.dateToDBTimeStr(dateRecord));
+                csvOutputFonte.write(DateConverter.dateTimeToDBDateStr(dateRecord));
+                csvOutputFonte.write(DateConverter.dateTimeToDBTimeStr(dateRecord));
                 csvOutputFonte.write(records.get(i).getExercise());
                 csvOutputFonte.write(Integer.toString(ExerciseType.STRENGTH.ordinal()));
                 csvOutputFonte.write(Long.toString(records.get(i).getProfileId()));

--- a/app/src/main/java/com/easyfitness/DAO/DAOUtils.java
+++ b/app/src/main/java/com/easyfitness/DAO/DAOUtils.java
@@ -4,5 +4,6 @@ package com.easyfitness.DAO;
 public class DAOUtils {
 
     public static final String DATE_FORMAT = "yyyy-MM-dd";
+    public static final String TIME_FORMAT = "HH:mm:ss";
 
 }

--- a/app/src/main/java/com/easyfitness/DAO/bodymeasures/DAOBodyMeasure.java
+++ b/app/src/main/java/com/easyfitness/DAO/bodymeasures/DAOBodyMeasure.java
@@ -6,17 +6,13 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
 import com.easyfitness.DAO.DAOBase;
-import com.easyfitness.DAO.DAOUtils;
 import com.easyfitness.DAO.Profile;
 import com.easyfitness.enums.Unit;
 import com.easyfitness.utils.DateConverter;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 
 public class DAOBodyMeasure extends DAOBase {
 

--- a/app/src/main/java/com/easyfitness/DAO/record/DAOCardio.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAOCardio.java
@@ -122,7 +122,7 @@ public class DAOCardio extends DAORecord {
             do {
                 Date date = DateConverter.DBDateStrToDate(mCursor.getString(1));
 
-                GraphData value = new GraphData(DateConverter.nbDays(date.getTime()),
+                GraphData value = new GraphData(DateConverter.nbDays(date),
                     mCursor.getDouble(0));
 
                 // Adding value to list

--- a/app/src/main/java/com/easyfitness/DAO/record/DAOCardio.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAOCardio.java
@@ -41,19 +41,18 @@ public class DAOCardio extends DAORecord {
 
     /**
      * @param pDate
-     * @param pTime
      * @param pMachine
      * @param pDistance
      * @param pDuration
      * @param pProfileId
      * @return
      */
-    public long addCardioRecord(Date pDate, String pTime, String pMachine, float pDistance, long pDuration, long pProfileId, DistanceUnit pDistanceUnit, long pTemplateRecordId) {
-        return addRecord(pDate, pTime, pMachine, ExerciseType.CARDIO, 0, 0, 0, WeightUnit.KG, 0, pDistance, pDistanceUnit, pDuration, "", pProfileId, pTemplateRecordId, RecordType.FREE_RECORD_TYPE);
+    public long addCardioRecord(Date pDate, String pMachine, float pDistance, long pDuration, long pProfileId, DistanceUnit pDistanceUnit, long pTemplateRecordId) {
+        return addRecord(pDate, pMachine, ExerciseType.CARDIO, 0, 0, 0, WeightUnit.KG, 0, pDistance, pDistanceUnit, pDuration, "", pProfileId, pTemplateRecordId, RecordType.FREE_RECORD_TYPE);
     }
 
-    public long addCardioRecordToProgramTemplate(long pTemplateId, long pTemplateSessionId, Date pDate, String pTime, String pExerciseName, float pDistance, DistanceUnit pDistanceUnit, long pDuration, int restTime) {
-        return addRecord(pDate, pTime, pExerciseName, ExerciseType.CARDIO, 0, 0, 0,
+    public long addCardioRecordToProgramTemplate(long pTemplateId, long pTemplateSessionId, Date pDate, String pExerciseName, float pDistance, DistanceUnit pDistanceUnit, long pDuration, int restTime) {
+        return addRecord(pDate, pExerciseName, ExerciseType.CARDIO, 0, 0, 0,
             WeightUnit.KG, "", pDistance, pDistanceUnit, pDuration, 0, -1,
             RecordType.TEMPLATE_TYPE, -1, pTemplateId, pTemplateSessionId,
             restTime, ProgramRecordStatus.NONE);

--- a/app/src/main/java/com/easyfitness/DAO/record/DAOCardio.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAOCardio.java
@@ -14,12 +14,9 @@ import com.easyfitness.R;
 import com.easyfitness.utils.DateConverter;
 import com.easyfitness.enums.ProgramRecordStatus;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 
 public class DAOCardio extends DAORecord {
 
@@ -71,40 +68,40 @@ public class DAOCardio extends DAORecord {
         }
 
         if (pFunction == DAOCardio.DISTANCE_FCT) {
-            selectQuery = "SELECT SUM(" + DISTANCE + "), " + DATE + " FROM " + TABLE_NAME
+            selectQuery = "SELECT SUM(" + DISTANCE + "), " + LOCAL_DATE + " FROM " + TABLE_NAME
                 + " WHERE " + EXERCISE + "=\"" + pMachine + "\""
                 + " AND " + PROFILE_KEY + "=" + pProfile.getId()
                 + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
                 + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal()
-                + " GROUP BY " + DATE
-                + " ORDER BY date(" + DATE + ") ASC";
+                + " GROUP BY " + LOCAL_DATE
+                + " ORDER BY " + DATE_TIME + " ASC";
         } else if (pFunction == DAOCardio.DURATION_FCT) {
-            selectQuery = "SELECT SUM(" + DURATION + ") , " + DATE + " FROM "
+            selectQuery = "SELECT SUM(" + DURATION + ") , " + LOCAL_DATE + " FROM "
                 + TABLE_NAME
                 + " WHERE " + EXERCISE + "=\"" + pMachine + "\""
                 + " AND " + PROFILE_KEY + "=" + pProfile.getId()
                 + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
                 + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal()
-                + " GROUP BY " + DATE
-                + " ORDER BY date(" + DATE + ") ASC";
+                + " GROUP BY " + LOCAL_DATE
+                + " ORDER BY " + DATE_TIME + " ASC";
         } else if (pFunction == DAOCardio.SPEED_FCT) {
-            selectQuery = "SELECT SUM(" + DISTANCE + ") / SUM(" + DURATION + ")," + DATE + " FROM "
+            selectQuery = "SELECT SUM(" + DISTANCE + ") / SUM(" + DURATION + ")," + LOCAL_DATE + " FROM "
                 + TABLE_NAME
                 + " WHERE " + EXERCISE + "=\"" + pMachine + "\""
                 + " AND " + PROFILE_KEY + "=" + pProfile.getId()
                 + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
                 + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal()
-                + " GROUP BY " + DATE
-                + " ORDER BY date(" + DATE + ") ASC";
+                + " GROUP BY " + LOCAL_DATE
+                + " ORDER BY " + DATE_TIME + " ASC";
         } else if (pFunction == DAOCardio.MAXDISTANCE_FCT) {
-            selectQuery = "SELECT MAX(" + DISTANCE + ") , " + DATE + " FROM "
+            selectQuery = "SELECT MAX(" + DISTANCE + ") , " + LOCAL_DATE + " FROM "
                 + TABLE_NAME
                 + " WHERE " + EXERCISE + "=\"" + pMachine + "\""
                 + " AND " + PROFILE_KEY + "=" + pProfile.getId()
                 + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
                 + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal()
-                + " GROUP BY " + DATE
-                + " ORDER BY date(" + DATE + ") ASC";
+                + " GROUP BY " + LOCAL_DATE
+                + " ORDER BY " + DATE_TIME + " ASC";
         }
         // case "MEAN" : selectQuery = "SELECT SUM("+ SERIE + "*" + REPETITION +
         // "*" + WEIGHT +") FROM " + TABLE_NAME + " WHERE " + EXERCISE + "=\"" +
@@ -123,15 +120,7 @@ public class DAOCardio extends DAORecord {
         // looping through all rows and adding to list
         if (mCursor.moveToFirst()) {
             do {
-                Date date;
-                try {
-                    SimpleDateFormat dateFormat = new SimpleDateFormat(DAOUtils.DATE_FORMAT);
-                    dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-                    date = dateFormat.parse(mCursor.getString(1));
-                } catch (ParseException e) {
-                    e.printStackTrace();
-                    date = new Date();
-                }
+                Date date = DateConverter.DBDateStrToDate(mCursor.getString(1));
 
                 GraphData value = new GraphData(DateConverter.nbDays(date.getTime()),
                     mCursor.getDouble(0));

--- a/app/src/main/java/com/easyfitness/DAO/record/DAOFonte.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAOFonte.java
@@ -16,12 +16,9 @@ import com.easyfitness.graph.GraphData;
 import com.easyfitness.utils.DateConverter;
 import com.easyfitness.enums.ProgramRecordStatus;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 
 public class DAOFonte extends DAORecord {
 
@@ -69,42 +66,42 @@ public class DAOFonte extends DAORecord {
         // TODO attention aux units de poids. Elles ne sont pas encore prise en compte ici.
         if (pFunction == DAOFonte.SUM_FCT) {
             selectQuery = "SELECT SUM(" + SETS + "*" + REPS + "*"
-                + WEIGHT + "), " + DATE + " FROM " + TABLE_NAME
+                + WEIGHT + "), " + LOCAL_DATE + " FROM " + TABLE_NAME
                 + " WHERE " + EXERCISE + "=\"" + pMachine + "\""
                 + " AND " + PROFILE_KEY + "=" + pProfile.getId()
                 + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
                 + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal()
-                + " GROUP BY " + DATE
-                + " ORDER BY date(" + DATE + ") ASC";
+                + " GROUP BY " + LOCAL_DATE
+                + " ORDER BY " + DATE_TIME + " ASC";
         } else if (pFunction == DAOFonte.MAX5_FCT) {
-            selectQuery = "SELECT MAX(" + WEIGHT + ") , " + DATE + " FROM "
+            selectQuery = "SELECT MAX(" + WEIGHT + ") , " + LOCAL_DATE + " FROM "
                 + TABLE_NAME
                 + " WHERE " + EXERCISE + "=\"" + pMachine + "\""
                 + " AND " + REPS + ">=5"
                 + " AND " + PROFILE_KEY + "=" + pProfile.getId()
                 + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
                 + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal()
-                + " GROUP BY " + DATE
-                + " ORDER BY date(" + DATE + ") ASC";
+                + " GROUP BY " + LOCAL_DATE
+                + " ORDER BY " + DATE_TIME + " ASC";
         } else if (pFunction == DAOFonte.MAX1_FCT) {
-            selectQuery = "SELECT MAX(" + WEIGHT + ") , " + DATE + " FROM "
+            selectQuery = "SELECT MAX(" + WEIGHT + ") , " + LOCAL_DATE + " FROM "
                 + TABLE_NAME
                 + " WHERE " + EXERCISE + "=\"" + pMachine + "\""
                 + " AND " + REPS + ">=1"
                 + " AND " + PROFILE_KEY + "=" + pProfile.getId()
                 + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
                 + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal()
-                + " GROUP BY " + DATE
-                + " ORDER BY date(" + DATE + ") ASC";
+                + " GROUP BY " + LOCAL_DATE
+                + " ORDER BY " + DATE_TIME + " ASC";
         } else if (pFunction == DAOFonte.NBSERIE_FCT) {
-            selectQuery = "SELECT count(" + KEY + ") , " + DATE + " FROM "
+            selectQuery = "SELECT count(" + KEY + ") , " + LOCAL_DATE + " FROM "
                 + TABLE_NAME
                 + " WHERE " + EXERCISE + "=\"" + pMachine + "\""
                 + " AND " + PROFILE_KEY + "=" + pProfile.getId()
                 + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
                 + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal()
-                + " GROUP BY " + DATE
-                + " ORDER BY date(" + DATE + ") ASC";
+                + " GROUP BY " + LOCAL_DATE
+                + " ORDER BY " + DATE_TIME + " ASC";
         }
 
         // Formation de tableau de valeur
@@ -119,15 +116,7 @@ public class DAOFonte extends DAORecord {
         // looping through all rows and adding to list
         if (mCursor.moveToFirst()) {
             do {
-                Date date;
-                try {
-                    SimpleDateFormat dateFormat = new SimpleDateFormat(DAOUtils.DATE_FORMAT);
-                    dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-                    date = dateFormat.parse(mCursor.getString(1));
-                } catch (ParseException e) {
-                    e.printStackTrace();
-                    date = new Date();
-                }
+                Date date = DateConverter.DBDateStrToDate(mCursor.getString(1));
 
                 GraphData value = new GraphData(DateConverter.nbDays(date.getTime()), mCursor.getDouble(0));
 
@@ -152,16 +141,14 @@ public class DAOFonte extends DAORecord {
         DAOMachine lDAOMachine = new DAOMachine(mContext);
         long machine_key = lDAOMachine.getMachine(pMachine).getId();
 
-        SimpleDateFormat dateFormat = new SimpleDateFormat(DAOUtils.DATE_FORMAT);
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-        String lDate = dateFormat.format(pDate);
+        String lDate = DateConverter.dateToDBDateStr(pDate);
 
         SQLiteDatabase db = this.getReadableDatabase();
         mCursor = null;
 
         // Select All Machines
         String selectQuery = "SELECT SUM(" + SETS + ") FROM " + TABLE_NAME
-            + " WHERE " + DATE + "=\"" + lDate + "\" AND " + EXERCISE_KEY + "=" + machine_key
+            + " WHERE " + LOCAL_DATE + "=\"" + lDate + "\" AND " + EXERCISE_KEY + "=" + machine_key
             + " AND " + PROFILE_KEY + "=" + pProfile.getId()
             + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
             + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal();
@@ -193,15 +180,13 @@ public class DAOFonte extends DAORecord {
         DAOMachine lDAOMachine = new DAOMachine(mContext);
         long machine_key = lDAOMachine.getMachine(pMachine).getId();
 
-        SimpleDateFormat dateFormat = new SimpleDateFormat(DAOUtils.DATE_FORMAT);
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-        String lDate = dateFormat.format(pDate);
+        String lDate = DateConverter.dateToDBDateStr(pDate);
 
         SQLiteDatabase db = this.getReadableDatabase();
         mCursor = null;
         // Select All Machines
         String selectQuery = "SELECT " + SETS + ", " + WEIGHT + ", " + REPS + " FROM " + TABLE_NAME
-            + " WHERE " + DATE + "=\"" + lDate + "\" AND " + EXERCISE_KEY + "=" + machine_key
+            + " WHERE " + LOCAL_DATE + "=\"" + lDate + "\" AND " + EXERCISE_KEY + "=" + machine_key
             + " AND " + PROFILE_KEY + "=" + pProfile.getId()
             + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
             + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal();
@@ -232,13 +217,11 @@ public class DAOFonte extends DAORecord {
         mCursor = null;
         float lReturn = 0;
 
-        SimpleDateFormat dateFormat = new SimpleDateFormat(DAOUtils.DATE_FORMAT);
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-        String lDate = dateFormat.format(pDate);
+        String lDate = DateConverter.dateToDBDateStr(pDate);
 
         // Select All Machines
         String selectQuery = "SELECT " + SETS + ", " + WEIGHT + ", " + REPS + " FROM " + TABLE_NAME
-            + " WHERE " + DATE + "=\"" + lDate + "\""
+            + " WHERE " + LOCAL_DATE + "=\"" + lDate + "\""
             + " AND " + PROFILE_KEY + "=" + pProfile.getId()
             + " AND " + TEMPLATE_RECORD_STATUS + "<" + ProgramRecordStatus.PENDING.ordinal()
             + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal();

--- a/app/src/main/java/com/easyfitness/DAO/record/DAOFonte.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAOFonte.java
@@ -19,7 +19,6 @@ import com.easyfitness.enums.ProgramRecordStatus;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
@@ -319,11 +318,7 @@ public class DAOFonte extends DAORecord {
     public void populate() {
         // DBORecord(long id, Date pDate, String pMachine, int pSerie, int
         // pRepetition, int pPoids)
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(Calendar.HOUR_OF_DAY, 12);
-        calendar.set(Calendar.MINUTE, 34);
-        calendar.set(Calendar.SECOND, 56);
-        Date date = calendar.getTime();
+        Date date = DateConverter.timeToDate(12, 34, 56);
         int poids = 10;
 
         for (int i = 1; i <= 5; i++) {
@@ -332,7 +327,7 @@ public class DAOFonte extends DAORecord {
             addBodyBuildingRecord(date, machine, i * 2, 10 + i, poids * i, WeightUnit.KG, "", mProfile.getId(), -1);
         }
 
-        date = calendar.getTime();
+        date = DateConverter.timeToDate(12, 34, 56);
         poids = 12;
 
         for (int i = 1; i <= 5; i++) {

--- a/app/src/main/java/com/easyfitness/DAO/record/DAOFonte.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAOFonte.java
@@ -19,6 +19,7 @@ import com.easyfitness.enums.ProgramRecordStatus;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
@@ -42,12 +43,12 @@ public class DAOFonte extends DAORecord {
      * @param pWeightUnit
      * @param pProfileId
      */
-    public long addBodyBuildingRecord(Date pDate, String pTime, String pExercise, int pSets, int pReps, float pWeight, WeightUnit pWeightUnit, String pNote, long pProfileId, long pTemplateRecordId) {
-        return addRecord(pDate, pTime, pExercise, ExerciseType.STRENGTH, pSets, pReps, pWeight, pWeightUnit, 0, 0, DistanceUnit.KM, 0, pNote, pProfileId, pTemplateRecordId, RecordType.FREE_RECORD_TYPE);
+    public long addBodyBuildingRecord(Date pDate, String pExercise, int pSets, int pReps, float pWeight, WeightUnit pWeightUnit, String pNote, long pProfileId, long pTemplateRecordId) {
+        return addRecord(pDate, pExercise, ExerciseType.STRENGTH, pSets, pReps, pWeight, pWeightUnit, 0, 0, DistanceUnit.KM, 0, pNote, pProfileId, pTemplateRecordId, RecordType.FREE_RECORD_TYPE);
     }
 
-    public long addWeightRecordToProgramTemplate(long pTemplateId, long pTemplateSessionId, Date pDate, String pTime, String pExerciseName, int pSets, int pReps, float pWeight, WeightUnit pWeightUnit, int restTime) {
-        return addRecord(pDate, pTime, pExerciseName, ExerciseType.STRENGTH, pSets, pReps, pWeight,
+    public long addWeightRecordToProgramTemplate(long pTemplateId, long pTemplateSessionId, Date pDate, String pExerciseName, int pSets, int pReps, float pWeight, WeightUnit pWeightUnit, int restTime) {
+        return addRecord(pDate, pExerciseName, ExerciseType.STRENGTH, pSets, pReps, pWeight,
             pWeightUnit, "", 0, DistanceUnit.KM, 0, 0, -1,
             RecordType.TEMPLATE_TYPE, -1, pTemplateId, pTemplateSessionId,
             restTime, ProgramRecordStatus.NONE);
@@ -318,22 +319,26 @@ public class DAOFonte extends DAORecord {
     public void populate() {
         // DBORecord(long id, Date pDate, String pMachine, int pSerie, int
         // pRepetition, int pPoids)
-        Date date = new Date();
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(Calendar.HOUR_OF_DAY, 12);
+        calendar.set(Calendar.MINUTE, 34);
+        calendar.set(Calendar.SECOND, 56);
+        Date date = calendar.getTime();
         int poids = 10;
 
         for (int i = 1; i <= 5; i++) {
             String machine = "Biceps";
             date.setDate(date.getDay() + i * 10);
-            addBodyBuildingRecord(date, "12:34:56", machine, i * 2, 10 + i, poids * i, WeightUnit.KG, "", mProfile.getId(), -1);
+            addBodyBuildingRecord(date, machine, i * 2, 10 + i, poids * i, WeightUnit.KG, "", mProfile.getId(), -1);
         }
 
-        date = new Date();
+        date = calendar.getTime();
         poids = 12;
 
         for (int i = 1; i <= 5; i++) {
             String machine = "Dev Couche";
             date.setDate(date.getDay() + i * 10);
-            addBodyBuildingRecord(date, "12:34:56", machine, i * 2, 10 + i, poids * i, WeightUnit.KG, "", mProfile.getId(), -1);
+            addBodyBuildingRecord(date, machine, i * 2, 10 + i, poids * i, WeightUnit.KG, "", mProfile.getId(), -1);
         }
     }
 

--- a/app/src/main/java/com/easyfitness/DAO/record/DAOFonte.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAOFonte.java
@@ -118,7 +118,7 @@ public class DAOFonte extends DAORecord {
             do {
                 Date date = DateConverter.DBDateStrToDate(mCursor.getString(1));
 
-                GraphData value = new GraphData(DateConverter.nbDays(date.getTime()), mCursor.getDouble(0));
+                GraphData value = new GraphData(DateConverter.nbDays(date), mCursor.getDouble(0));
 
                 // Adding value to list
                 valueList.add(value);

--- a/app/src/main/java/com/easyfitness/DAO/record/DAORecord.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAORecord.java
@@ -189,8 +189,8 @@ public class DAORecord extends DAOBase {
             templateOrder = records.size();
         }
 
-        value.put(DAORecord.DATE, DateConverter.dateToDBDateStr(pDate));
-        value.put(DAORecord.TIME, DateConverter.dateToDBTimeStr(pDate));
+        value.put(DAORecord.DATE, DateConverter.dateTimeToDBDateStr(pDate));
+        value.put(DAORecord.TIME, DateConverter.dateTimeToDBTimeStr(pDate));
         value.put(DAORecord.EXERCISE, pExercise);
         value.put(DAORecord.EXERCISE_KEY, machine_key);
         value.put(DAORecord.EXERCISE_TYPE, pExerciseType.ordinal());
@@ -722,8 +722,8 @@ public class DAORecord extends DAOBase {
         ContentValues value = new ContentValues();
 
         value.put(DAORecord.KEY, record.getId());
-        value.put(DAORecord.DATE, DateConverter.dateToDBDateStr(record.getDate()));
-        value.put(DAORecord.TIME, DateConverter.dateToDBTimeStr(record.getDate()));
+        value.put(DAORecord.DATE, DateConverter.dateTimeToDBDateStr(record.getDate()));
+        value.put(DAORecord.TIME, DateConverter.dateTimeToDBTimeStr(record.getDate()));
         value.put(DAORecord.EXERCISE, record.getExercise());
         value.put(DAORecord.EXERCISE_KEY, record.getExerciseId());
         value.put(DAORecord.EXERCISE_TYPE, record.getExerciseType().ordinal());

--- a/app/src/main/java/com/easyfitness/DAO/record/DAORecord.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAORecord.java
@@ -131,7 +131,7 @@ public class DAORecord extends DAOBase {
     }
 
     public long addRecord(Record record) {
-        return addRecord(record.getDate(), record.getTime(),
+        return addRecord(record.getDate(),
             record.getExercise(), record.getExerciseType(),
             record.getSets(), record.getReps(), record.getWeight(), record.getWeightUnit(),
             record.getNote(),
@@ -148,10 +148,10 @@ public class DAORecord extends DAOBase {
      * @param pTemplateRecordId Id of the Template record that has been used to generate this Record
      * @return id of the added record, -1 if error
      */
-    public long addRecord(Date pDate, String pTime, String pExercise, ExerciseType pExerciseType, int pSets, int pReps, float pWeight,
+    public long addRecord(Date pDate, String pExercise, ExerciseType pExerciseType, int pSets, int pReps, float pWeight,
                           WeightUnit pUnit, int pSeconds, float pDistance, DistanceUnit pDistanceUnit, long pDuration, String pNote, long pProfileId,
                           long pTemplateRecordId, RecordType pRecordType){
-        return addRecord(pDate, pTime, pExercise, pExerciseType, pSets, pReps, pWeight, pUnit, pNote, pDistance, pDistanceUnit, pDuration, pSeconds, pProfileId,
+        return addRecord(pDate, pExercise, pExerciseType, pSets, pReps, pWeight, pUnit, pNote, pDistance, pDistanceUnit, pDuration, pSeconds, pProfileId,
             pRecordType, pTemplateRecordId, -1, -1, 0, ProgramRecordStatus.SUCCESS);
     }
 
@@ -165,7 +165,7 @@ public class DAORecord extends DAOBase {
      * @param pTemplateSessionId
      * @return id of the added record, -1 if error
      */
-    public long addRecord(Date pDate, String pTime, String pExercise, ExerciseType pExerciseType, int pSets, int pReps, float pWeight,
+    public long addRecord(Date pDate, String pExercise, ExerciseType pExerciseType, int pSets, int pReps, float pWeight,
                           WeightUnit pWeightUnit, String pNote, float pDistance, DistanceUnit pDistanceUnit, long pDuration, int pSeconds, long pProfileId,
                           RecordType pRecordType, long pTemplateRecordId, long pTemplateId, long pTemplateSessionId,
                           int pRestTime, ProgramRecordStatus pProgramRecordStatus) {
@@ -190,7 +190,7 @@ public class DAORecord extends DAOBase {
         }
 
         value.put(DAORecord.DATE, DateConverter.dateToDBDateStr(pDate));
-        value.put(DAORecord.TIME, pTime);
+        value.put(DAORecord.TIME, DateConverter.dateToDBTimeStr(pDate));
         value.put(DAORecord.EXERCISE, pExercise);
         value.put(DAORecord.EXERCISE_KEY, machine_key);
         value.put(DAORecord.EXERCISE_TYPE, pExerciseType.ordinal());
@@ -221,7 +221,7 @@ public class DAORecord extends DAOBase {
 
     public void addList(List<Record> list) {
         for (Record record: list) {
-            addRecord(record.getDate(), record.getTime(),
+            addRecord(record.getDate(),
                 record.getExercise(), record.getExerciseType(),
                 record.getSets(), record.getReps(), record.getWeight(), record.getWeightUnit(),
                 record.getSeconds(),
@@ -254,7 +254,10 @@ public class DAORecord extends DAOBase {
     }
 
     private Record fromCursor(Cursor cursor) {
-        Date date = DateConverter.DBDateStrToDate(cursor.getString(cursor.getColumnIndex(DAOFonte.DATE)));
+        Date date = DateConverter.DBDateTimeStrToDate(
+            cursor.getString(cursor.getColumnIndex(DAOFonte.DATE)),
+            cursor.getString(cursor.getColumnIndex(DAOFonte.TIME))
+        );
 
         long machine_key = -1;
 
@@ -267,7 +270,6 @@ public class DAORecord extends DAOBase {
         }
 
         Record value = new Record(date,
-            cursor.getString(cursor.getColumnIndex(DAORecord.TIME)),
             cursor.getString(cursor.getColumnIndex(DAORecord.EXERCISE)),
             machine_key,
             cursor.getLong(cursor.getColumnIndex(DAORecord.PROFILE_KEY)),
@@ -721,7 +723,7 @@ public class DAORecord extends DAOBase {
 
         value.put(DAORecord.KEY, record.getId());
         value.put(DAORecord.DATE, DateConverter.dateToDBDateStr(record.getDate()));
-        value.put(DAORecord.TIME, record.getTime());
+        value.put(DAORecord.TIME, DateConverter.dateToDBTimeStr(record.getDate()));
         value.put(DAORecord.EXERCISE, record.getExercise());
         value.put(DAORecord.EXERCISE_KEY, record.getExerciseId());
         value.put(DAORecord.EXERCISE_TYPE, record.getExerciseType().ordinal());

--- a/app/src/main/java/com/easyfitness/DAO/record/DAOStatic.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAOStatic.java
@@ -16,12 +16,9 @@ import com.easyfitness.graph.GraphData;
 import com.easyfitness.utils.DateConverter;
 import com.easyfitness.enums.ProgramRecordStatus;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 
 public class DAOStatic extends DAORecord {
 
@@ -69,23 +66,23 @@ public class DAOStatic extends DAORecord {
                 + " GROUP BY " + SECONDS
                 + " ORDER BY " + SECONDS + " ASC";
         } else if (pFunction == DAOStatic.MAX_LENGTH) {
-            selectQuery = "SELECT MAX(" + SECONDS + ") , " + DATE + " FROM "
+            selectQuery = "SELECT MAX(" + SECONDS + ") , " + LOCAL_DATE + " FROM "
                 + TABLE_NAME
                 + " WHERE " + EXERCISE + "=\"" + pMachine + "\""
                 + " AND " + PROFILE_KEY + "=" + pProfile.getId()
                 + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
                 + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal()
-                + " GROUP BY " + DATE
-                + " ORDER BY date(" + DATE + ") ASC";
+                + " GROUP BY " + LOCAL_DATE
+                + " ORDER BY " + DATE_TIME + " ASC";
         } else if (pFunction == DAOStatic.NBSERIE_FCT) {
-            selectQuery = "SELECT count(" + KEY + ") , " + DATE + " FROM "
+            selectQuery = "SELECT count(" + KEY + ") , " + LOCAL_DATE + " FROM "
                 + TABLE_NAME
                 + " WHERE " + EXERCISE + "=\"" + pMachine + "\""
                 + " AND " + PROFILE_KEY + "=" + pProfile.getId()
                 + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
                 + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal()
-                + " GROUP BY " + DATE
-                + " ORDER BY date(" + DATE + ") ASC";
+                + " GROUP BY " + LOCAL_DATE
+                + " ORDER BY " + DATE_TIME + " ASC";
         } else {
             return null;
         }
@@ -104,16 +101,7 @@ public class DAOStatic extends DAORecord {
             if (mCursor.moveToFirst()) {
                 do {
 
-                    Date date;
-                    try {
-                        SimpleDateFormat dateFormat = new SimpleDateFormat(DAOUtils.DATE_FORMAT);
-                        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-                        date = dateFormat.parse(mCursor.getString(1));
-                    } catch (ParseException e) {
-                        e.printStackTrace();
-                        date = new Date();
-                    }
-
+                    Date date = DateConverter.DBDateStrToDate(mCursor.getString(1));
                     GraphData value = new GraphData(DateConverter.nbDays(date.getTime()), mCursor.getDouble(0));
 
                     // Adding value to list
@@ -144,16 +132,14 @@ public class DAOStatic extends DAORecord {
         DAOMachine lDAOMachine = new DAOMachine(mContext);
         long machine_key = lDAOMachine.getMachine(pMachine).getId();
 
-        SimpleDateFormat dateFormat = new SimpleDateFormat(DAOUtils.DATE_FORMAT);
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-        String lDate = dateFormat.format(pDate);
+        String lDate = DateConverter.dateToDBDateStr(pDate);
 
         SQLiteDatabase db = this.getReadableDatabase();
         mCursor = null;
 
         // Select All Machines
         String selectQuery = "SELECT SUM(" + SETS + ") FROM " + TABLE_NAME
-            + " WHERE " + DATE + "=\"" + lDate + "\" AND " + EXERCISE_KEY + "=" + machine_key
+            + " WHERE " + LOCAL_DATE + "=\"" + lDate + "\" AND " + EXERCISE_KEY + "=" + machine_key
             + " AND " + PROFILE_KEY + "=" + pProfile.getId()
             + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
             + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal();
@@ -185,15 +171,13 @@ public class DAOStatic extends DAORecord {
         DAOMachine lDAOMachine = new DAOMachine(mContext);
         long machine_key = lDAOMachine.getMachine(pMachine).getId();
 
-        SimpleDateFormat dateFormat = new SimpleDateFormat(DAOUtils.DATE_FORMAT);
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-        String lDate = dateFormat.format(pDate);
+        String lDate = DateConverter.dateToDBDateStr(pDate);
 
         SQLiteDatabase db = this.getReadableDatabase();
         mCursor = null;
         // Select All Machines
         String selectQuery = "SELECT " + SETS + ", " + WEIGHT + " FROM " + TABLE_NAME
-            + " WHERE " + DATE + "=\"" + lDate + "\" AND " + EXERCISE_KEY + "=" + machine_key
+            + " WHERE " + LOCAL_DATE + "=\"" + lDate + "\" AND " + EXERCISE_KEY + "=" + machine_key
             + " AND " + PROFILE_KEY + "=" + pProfile.getId()
             + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
             + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal();
@@ -224,13 +208,11 @@ public class DAOStatic extends DAORecord {
         mCursor = null;
         float lReturn = 0;
 
-        SimpleDateFormat dateFormat = new SimpleDateFormat(DAOUtils.DATE_FORMAT);
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-        String lDate = dateFormat.format(pDate);
+        String lDate = DateConverter.dateToDBDateStr(pDate);
 
         // Select All Machines
         String selectQuery = "SELECT " + SETS + ", " + WEIGHT  + " FROM " + TABLE_NAME
-            + " WHERE " + DATE + "=\"" + lDate + "\""
+            + " WHERE " + LOCAL_DATE + "=\"" + lDate + "\""
             + " AND " + PROFILE_KEY + "=" + pProfile.getId()
             + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
             + " AND " + RECORD_TYPE + "!=" + RecordType.TEMPLATE_TYPE.ordinal();

--- a/app/src/main/java/com/easyfitness/DAO/record/DAOStatic.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAOStatic.java
@@ -102,7 +102,7 @@ public class DAOStatic extends DAORecord {
                 do {
 
                     Date date = DateConverter.DBDateStrToDate(mCursor.getString(1));
-                    GraphData value = new GraphData(DateConverter.nbDays(date.getTime()), mCursor.getDouble(0));
+                    GraphData value = new GraphData(DateConverter.nbDays(date), mCursor.getDouble(0));
 
                     // Adding value to list
                     valueList.add(value);

--- a/app/src/main/java/com/easyfitness/DAO/record/DAOStatic.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAOStatic.java
@@ -41,12 +41,12 @@ public class DAOStatic extends DAORecord {
      * @param pMachine Machine name
      * @param pProfileId Profile ID
      */
-    public long addStaticRecord(Date pDate, String pMachine, int pSerie, int pSeconds, float pPoids, long pProfileId, WeightUnit pUnit, String pNote, String pTime, long pTemplateRecordId) {
-        return addRecord(pDate, pTime, pMachine, ExerciseType.ISOMETRIC, pSerie, 0, pPoids, pUnit, pSeconds, 0, DistanceUnit.KM, 0, pNote, pProfileId, pTemplateRecordId, RecordType.FREE_RECORD_TYPE);
+    public long addStaticRecord(Date pDate, String pMachine, int pSerie, int pSeconds, float pPoids, long pProfileId, WeightUnit pUnit, String pNote, long pTemplateRecordId) {
+        return addRecord(pDate, pMachine, ExerciseType.ISOMETRIC, pSerie, 0, pPoids, pUnit, pSeconds, 0, DistanceUnit.KM, 0, pNote, pProfileId, pTemplateRecordId, RecordType.FREE_RECORD_TYPE);
     }
 
-    public long addStaticRecordToProgramTemplate(long pTemplateId, long pTemplateSessionId,Date pDate, String pTime, String pExerciseName, int pSets, int pSeconds, float pWeight, WeightUnit pWeightUnit, int restTime) {
-        return addRecord(pDate, pTime, pExerciseName, ExerciseType.ISOMETRIC, pSets, 0, pWeight,
+    public long addStaticRecordToProgramTemplate(long pTemplateId, long pTemplateSessionId,Date pDate, String pExerciseName, int pSets, int pSeconds, float pWeight, WeightUnit pWeightUnit, int restTime) {
+        return addRecord(pDate, pExerciseName, ExerciseType.ISOMETRIC, pSets, 0, pWeight,
             pWeightUnit, "", 0, DistanceUnit.KM, 0, pSeconds, -1,
             RecordType.TEMPLATE_TYPE, -1, pTemplateId, pTemplateSessionId,
             restTime, ProgramRecordStatus.NONE);

--- a/app/src/main/java/com/easyfitness/DAO/record/Record.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/Record.java
@@ -14,7 +14,6 @@ public class Record {
     private long mId;
 
     private Date mDate;
-    private String mTime; // Time in HH:MM:SS
     private String mExercise;
     private long mExerciseId;
     private long mProfileId;
@@ -44,13 +43,12 @@ public class Record {
     private int mTemplateOrder;
     private ProgramRecordStatus mProgramRecordStatus;
 
-    public Record(Date date, String time, String exercise, long exerciseId, long profileId, int sets, int reps, float weight, WeightUnit weightUnit, int second, float distance, DistanceUnit distanceUnit, long duration, String note, ExerciseType exerciseType, long recordTemplateId) {
-        this(date, time, exercise,  exerciseId, profileId,  sets, reps, weight, weightUnit, second, distance, distanceUnit, duration, note, exerciseType, -1, recordTemplateId, -1, 0, 0, ProgramRecordStatus.SUCCESS, RecordType.FREE_RECORD_TYPE);
+    public Record(Date date, String exercise, long exerciseId, long profileId, int sets, int reps, float weight, WeightUnit weightUnit, int second, float distance, DistanceUnit distanceUnit, long duration, String note, ExerciseType exerciseType, long recordTemplateId) {
+        this(date, exercise,  exerciseId, profileId,  sets, reps, weight, weightUnit, second, distance, distanceUnit, duration, note, exerciseType, -1, recordTemplateId, -1, 0, 0, ProgramRecordStatus.SUCCESS, RecordType.FREE_RECORD_TYPE);
     }
 
-    public Record(Date date, String time, String exercise, long exerciseId, long profileId, int sets, int reps, float weight, WeightUnit weightUnit, int second, float distance, DistanceUnit distanceUnit, long duration, String note, ExerciseType exerciseType, long templateId, long templateRecordId, long templateSessionId, int restTime, int templateOrder, ProgramRecordStatus programRecordStatus, RecordType recordType) {
+    public Record(Date date, String exercise, long exerciseId, long profileId, int sets, int reps, float weight, WeightUnit weightUnit, int second, float distance, DistanceUnit distanceUnit, long duration, String note, ExerciseType exerciseType, long templateId, long templateRecordId, long templateSessionId, int restTime, int templateOrder, ProgramRecordStatus programRecordStatus, RecordType recordType) {
         mDate = date;
-        mTime = time;
         mExercise = exercise;
         mExerciseId = exerciseId;
         mProfileId = profileId;
@@ -87,14 +85,6 @@ public class Record {
 
     public void setDate(Date date) {
         mDate = date;
-    }
-
-    public String getTime() {
-        return mTime;
-    }
-
-    public void setTime(String time) {
-        mTime = time;
     }
 
     public String getExercise() {

--- a/app/src/main/java/com/easyfitness/MainActivity.java
+++ b/app/src/main/java/com/easyfitness/MainActivity.java
@@ -380,8 +380,8 @@ public class MainActivity extends AppCompatActivity {
             }
             DAOCardio lDbCardio = new DAOCardio(this);
             if(lDbCardio.getCount()==0) {
-                lDbCardio.addCardioRecord(DateConverter.DBDateTimeStrToDate("2019-07-01", DateConverter.currentTime()), "Running Example", 1, 10000, this.getCurrentProfile().getId(), DistanceUnit.KM, -1);
-                lDbCardio.addCardioRecord(DateConverter.DBDateTimeStrToDate("2019-07-31", DateConverter.currentTime()), "Cardio Example", UnitConverter.MilesToKm(2), 20000, this.getCurrentProfile().getId(), DistanceUnit.MILES, -1);
+                lDbCardio.addCardioRecord(DateConverter.dateToDate(2019, 07, 01), "Running Example", 1, 10000, this.getCurrentProfile().getId(), DistanceUnit.KM, -1);
+                lDbCardio.addCardioRecord(DateConverter.dateToDate(2019, 07, 31), "Cardio Example", UnitConverter.MilesToKm(2), 20000, this.getCurrentProfile().getId(), DistanceUnit.MILES, -1);
             }
             DAOStatic lDbStatic = new DAOStatic(this);
             if(lDbStatic.getCount()==0) {

--- a/app/src/main/java/com/easyfitness/MainActivity.java
+++ b/app/src/main/java/com/easyfitness/MainActivity.java
@@ -285,7 +285,7 @@ public class MainActivity extends AppCompatActivity {
                         }
                     }
 
-                    mDbCardio.addCardioRecord(record.getDate(), "00:00:00", exerciseName, record.getDistance(), record.getDuration(), record.getProfil().getId(), DistanceUnit.KM, -1);
+                    mDbCardio.addCardioRecord(record.getDate(), exerciseName, record.getDistance(), record.getDuration(), record.getProfil().getId(), DistanceUnit.KM, -1);
                 }
                 mDbOldCardio.dropTable();
 
@@ -375,18 +375,18 @@ public class MainActivity extends AppCompatActivity {
             // do something for a debug build
             DAOFonte lDbFonte = new DAOFonte(this);
             if(lDbFonte.getCount()==0) {
-                lDbFonte.addBodyBuildingRecord(DateConverter.dateToDate(2019, 07, 01), "12:34:56", "Example 1", 1, 10, 40, WeightUnit.KG, "", this.getCurrentProfile().getId(), -1);
-                lDbFonte.addBodyBuildingRecord(DateConverter.dateToDate(2019, 06, 30), "12:34:56", "Example 2", 1, 10, UnitConverter.LbstoKg(60), WeightUnit.LBS, "", this.getCurrentProfile().getId(), -1);
+                lDbFonte.addBodyBuildingRecord(DateConverter.dateToDate(2019, 07, 01, 12, 34, 56), "Example 1", 1, 10, 40, WeightUnit.KG, "", this.getCurrentProfile().getId(), -1);
+                lDbFonte.addBodyBuildingRecord(DateConverter.dateToDate(2019, 06, 30, 12, 34, 56), "Example 2", 1, 10, UnitConverter.LbstoKg(60), WeightUnit.LBS, "", this.getCurrentProfile().getId(), -1);
             }
             DAOCardio lDbCardio = new DAOCardio(this);
             if(lDbCardio.getCount()==0) {
-                lDbCardio.addCardioRecord(DateConverter.dateToDate(2019, 07, 01),  DateConverter.currentTime(), "Running Example", 1, 10000, this.getCurrentProfile().getId(), DistanceUnit.KM, -1);
-                lDbCardio.addCardioRecord(DateConverter.dateToDate(2019, 07, 31), DateConverter.currentTime(), "Cardio Example", UnitConverter.MilesToKm(2), 20000, this.getCurrentProfile().getId(), DistanceUnit.MILES, -1);
+                lDbCardio.addCardioRecord(DateConverter.DBDateTimeStrToDate("2019-07-01", DateConverter.currentTime()), "Running Example", 1, 10000, this.getCurrentProfile().getId(), DistanceUnit.KM, -1);
+                lDbCardio.addCardioRecord(DateConverter.DBDateTimeStrToDate("2019-07-31", DateConverter.currentTime()), "Cardio Example", UnitConverter.MilesToKm(2), 20000, this.getCurrentProfile().getId(), DistanceUnit.MILES, -1);
             }
             DAOStatic lDbStatic = new DAOStatic(this);
             if(lDbStatic.getCount()==0) {
-                lDbStatic.addStaticRecord(DateConverter.dateToDate(2019, 07, 01), "Exercise ISO 1", 1, 50, 40, this.getCurrentProfile().getId(), WeightUnit.KG, "", "12:34:56", -1);
-                lDbStatic.addStaticRecord(DateConverter.dateToDate(2019, 07, 31), "Exercise ISO 2", 1, 60, UnitConverter.LbstoKg(40), this.getCurrentProfile().getId(), WeightUnit.LBS, "", "12:34:56", -1);
+                lDbStatic.addStaticRecord(DateConverter.dateToDate(2019, 07, 01, 12, 34, 56), "Exercise ISO 1", 1, 50, 40, this.getCurrentProfile().getId(), WeightUnit.KG, "", -1);
+                lDbStatic.addStaticRecord(DateConverter.dateToDate(2019, 07, 31, 12, 34, 56), "Exercise ISO 2", 1, 60, UnitConverter.LbstoKg(40), this.getCurrentProfile().getId(), WeightUnit.LBS, "", -1);
             }
             DAOProgram lDbWorkout = new DAOProgram(this);
             if(lDbWorkout.getCount()==0) {

--- a/app/src/main/java/com/easyfitness/WeightFragment.java
+++ b/app/src/main/java/com/easyfitness/WeightFragment.java
@@ -340,7 +340,7 @@ public class WeightFragment extends Fragment {
 
             if (valueList.size() > 0) {
                 for (int i = valueList.size() - 1; i >= 0; i--) {
-                    Entry value = new Entry((float) DateConverter.nbDays(valueList.get(i).getDate().getTime()), UnitConverter.weightConverter(valueList.get(i).getBodyMeasure(),valueList.get(i).getUnit(), Unit.KG));
+                    Entry value = new Entry((float) DateConverter.nbDays(valueList.get(i).getDate()), UnitConverter.weightConverter(valueList.get(i).getBodyMeasure(),valueList.get(i).getUnit(), Unit.KG));
                     yVals.add(value);
                 }
 
@@ -364,7 +364,7 @@ public class WeightFragment extends Fragment {
 
             if ( valueList.size() > 0) {
                 for (int i = valueList.size() - 1; i >= 0; i--) {
-                    Entry value = new Entry((float) DateConverter.nbDays(valueList.get(i).getDate().getTime()), valueList.get(i).getBodyMeasure());
+                    Entry value = new Entry((float) DateConverter.nbDays(valueList.get(i).getDate()), valueList.get(i).getBodyMeasure());
                     yVals.add(value);
                 }
 
@@ -385,7 +385,7 @@ public class WeightFragment extends Fragment {
 
             if ( valueList.size() > 0) {
                 for (int i = valueList.size() - 1; i >= 0; i--) {
-                    Entry value = new Entry((float) DateConverter.nbDays(valueList.get(i).getDate().getTime()), valueList.get(i).getBodyMeasure());
+                    Entry value = new Entry((float) DateConverter.nbDays(valueList.get(i).getDate()), valueList.get(i).getBodyMeasure());
                     yVals.add(value);
                 }
 
@@ -407,7 +407,7 @@ public class WeightFragment extends Fragment {
 
             if ( valueList.size() > 0) {
                 for (int i = valueList.size() - 1; i >= 0; i--) {
-                    Entry value = new Entry((float) DateConverter.nbDays(valueList.get(i).getDate().getTime()), valueList.get(i).getBodyMeasure());
+                    Entry value = new Entry((float) DateConverter.nbDays(valueList.get(i).getDate()), valueList.get(i).getBodyMeasure());
                     yVals.add(value);
                 }
 

--- a/app/src/main/java/com/easyfitness/bodymeasures/BodyPartDetailsFragment.java
+++ b/app/src/main/java/com/easyfitness/bodymeasures/BodyPartDetailsFragment.java
@@ -298,7 +298,7 @@ public class BodyPartDetailsFragment extends Fragment implements DatePickerDialo
                     normalizedMeasure=valueList.get(i).getBodyMeasure();
             }
 
-            Entry value = new Entry((float) DateConverter.nbDays(valueList.get(i).getDate().getTime()), normalizedMeasure);
+            Entry value = new Entry((float) DateConverter.nbDays(valueList.get(i).getDate()), normalizedMeasure);
             yVals.add(value);
             if (minBodyMeasure == -1) minBodyMeasure = valueList.get(i).getBodyMeasure();
             else if (valueList.get(i).getBodyMeasure() < minBodyMeasure)

--- a/app/src/main/java/com/easyfitness/bodymeasures/BodyPartListAdapter.java
+++ b/app/src/main/java/com/easyfitness/bodymeasures/BodyPartListAdapter.java
@@ -97,7 +97,7 @@ public class BodyPartListAdapter extends ArrayAdapter<BodyPart> implements View.
 
                         if (valueList.size() > 0) {
                             for (int i = valueList.size() - 1; i >= 0; i--) {
-                                Entry value = new Entry((float) DateConverter.nbDays(valueList.get(i).getDate().getTime()), valueList.get(i).getBodyMeasure());
+                                Entry value = new Entry((float) DateConverter.nbDays(valueList.get(i).getDate()), valueList.get(i).getBodyMeasure());
                                 yVals.add(value);
                             }
 

--- a/app/src/main/java/com/easyfitness/fonte/FontesFragment.java
+++ b/app/src/main/java/com/easyfitness/fonte/FontesFragment.java
@@ -192,15 +192,12 @@ public class FontesFragment extends Fragment {
             return;
         }
 
-        String timeStr;
         Date date;
 
         if (autoTimeCheckBox.isChecked()) {
             date = new Date();
-            timeStr = DateConverter.currentTime();
         }else {
-            date = DateConverter.editToDate(dateEdit.getText().toString());
-            timeStr = timeEdit.getText().toString();
+            date = DateConverter.editToDateTime(dateEdit.getText().toString(), timeEdit.getText().toString());
         }
 
         ExerciseType exerciseType;
@@ -222,7 +219,7 @@ public class FontesFragment extends Fragment {
             tmpPoids = UnitConverter.weightConverter(tmpPoids,workoutValuesInputView.getWeightUnit(), WeightUnit.KG); // Always convert to KG
 
             if(mDisplayType == DisplayType.FREE_WORKOUT_DISPLAY) {
-                mDbBodyBuilding.addBodyBuildingRecord(date, timeStr,
+                mDbBodyBuilding.addBodyBuildingRecord(date,
                     machineEdit.getText().toString(),
                     workoutValuesInputView.getSets(),
                     workoutValuesInputView.getReps(),
@@ -249,7 +246,7 @@ public class FontesFragment extends Fragment {
                 }
             } else if (mDisplayType == DisplayType.PROGRAM_EDIT_DISPLAY) {
                 for (int i = 0; i<workoutValuesInputView.getSets(); i++ ) {
-                    mDbBodyBuilding.addWeightRecordToProgramTemplate(mTemplateId, -1, date, timeStr,
+                    mDbBodyBuilding.addWeightRecordToProgramTemplate(mTemplateId, -1, date,
                         machineEdit.getText().toString(),
                         1,
                         workoutValuesInputView.getReps(),
@@ -279,7 +276,7 @@ public class FontesFragment extends Fragment {
                     getProfile().getId(),
                     workoutValuesInputView.getWeightUnit(), // Store Unit for future display
                     "", //Notes
-                    timeStr, -1
+                    -1
                 );
 
                 float iTotalWeightSession = mDbStatic.getTotalWeightSession(date, getProfile());
@@ -300,7 +297,7 @@ public class FontesFragment extends Fragment {
                 }
             } else if (mDisplayType == DisplayType.PROGRAM_EDIT_DISPLAY) {
                 for (int i = 0; i<workoutValuesInputView.getSets(); i++ ) {
-                    mDbStatic.addStaticRecordToProgramTemplate(mTemplateId, -1, date, timeStr,
+                    mDbStatic.addStaticRecordToProgramTemplate(mTemplateId, -1, date,
                         machineEdit.getText().toString(),
                         1,
                         workoutValuesInputView.getSeconds(),
@@ -326,7 +323,6 @@ public class FontesFragment extends Fragment {
 
             if (mDisplayType == DisplayType.FREE_WORKOUT_DISPLAY) {
                 mDbCardio.addCardioRecord(date,
-                    timeStr,
                     machineEdit.getText().toString(),
                     distance,
                     duration,
@@ -345,7 +341,6 @@ public class FontesFragment extends Fragment {
             } else if (mDisplayType == DisplayType.PROGRAM_EDIT_DISPLAY) {
                 mDbCardio.addCardioRecordToProgramTemplate(mTemplateId, -1,
                     date,
-                    timeStr,
                     machineEdit.getText().toString(),
                     distance,
                     workoutValuesInputView.getDistanceUnit(),

--- a/app/src/main/java/com/easyfitness/fonte/FontesFragment.java
+++ b/app/src/main/java/com/easyfitness/fonte/FontesFragment.java
@@ -70,6 +70,7 @@ import com.onurkaganaldemir.ktoastlib.KToast;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
@@ -111,19 +112,8 @@ public class FontesFragment extends Fragment {
 
     private MyTimePickerDialog.OnTimeSetListener timeSet = (view, hourOfDay, minute, second) -> {
         // Do something with the time chosen by the user
-        String strMinute = "00";
-        String strHour = "00";
-        String strSecond = "00";
-
-        if (minute < 10) strMinute = "0" + minute;
-        else strMinute = Integer.toString(minute);
-        if (hourOfDay < 10) strHour = "0" + hourOfDay;
-        else strHour = Integer.toString(hourOfDay);
-        if (second < 10) strSecond = "0" + second;
-        else strSecond = Integer.toString(second);
-
-        String date = strHour + ":" + strMinute + ":" + strSecond;
-        timeEdit.setText(date);
+        Date date = DateConverter.timeToDate(hourOfDay, minute, second);
+        timeEdit.setText(DateConverter.dateToLocalTimeStr(date, getContext()));
         Keyboard.hide(getContext(), timeEdit);
     };
     private OnClickListener collapseDetailsClick = v -> {
@@ -197,7 +187,7 @@ public class FontesFragment extends Fragment {
         if (autoTimeCheckBox.isChecked()) {
             date = new Date();
         }else {
-            date = DateConverter.editToDateTime(dateEdit.getText().toString(), timeEdit.getText().toString());
+            date = DateConverter.localDateTimeStrToDateTime(dateEdit.getText().toString(), timeEdit.getText().toString(), getContext());
         }
 
         ExerciseType exerciseType;
@@ -359,7 +349,7 @@ public class FontesFragment extends Fragment {
 
         //Rajoute le moment du dernier ajout dans le bouton Add
         if (mDisplayType == DisplayType.FREE_WORKOUT_DISPLAY)
-            addButton.setText(getView().getContext().getString(R.string.AddLabel) + "\n(" + DateConverter.currentTime() + ")");
+            addButton.setText(getView().getContext().getString(R.string.AddLabel) + "\n(" + DateConverter.currentTime(getContext()) + ")");
 
         mDbCardio.closeCursor();
         mDbBodyBuilding.closeCursor();
@@ -429,7 +419,7 @@ public class FontesFragment extends Fragment {
     };
     private OnItemClickListener onItemClickFilterList = (parent, view, position, id) -> setCurrentMachine(machineEdit.getText().toString());
     private DatePickerDialog.OnDateSetListener dateSet = (view, year, month, day) -> {
-        dateEdit.setText(DateConverter.dateToString(year, month + 1, day));
+        dateEdit.setText(DateConverter.dateToLocalDateStr(year, month, day, getContext()));
         Keyboard.hide(getContext(), dateEdit);
     };
     private OnClickListener clickDateEdit = v -> {
@@ -479,8 +469,8 @@ public class FontesFragment extends Fragment {
         dateEdit.setEnabled(!isChecked);
         timeEdit.setEnabled(!isChecked);
         if (isChecked) {
-            dateEdit.setText(DateConverter.currentDate());
-            timeEdit.setText(DateConverter.currentTime());
+            dateEdit.setText(DateConverter.currentDate(getContext()));
+            timeEdit.setText(DateConverter.currentTime(getContext()));
         }
     };
     private ProfileViMo profileViMo;
@@ -586,8 +576,8 @@ public class FontesFragment extends Fragment {
     public void onStart() {
         super.onStart();
         this.mActivity = (MainActivity) this.getActivity();
-        dateEdit.setText(DateConverter.currentDate());
-        timeEdit.setText(DateConverter.currentTime());
+        dateEdit.setText(DateConverter.currentDate(getContext()));
+        timeEdit.setText(DateConverter.currentTime(getContext()));
         if (mDisplayType==DisplayType.PROGRAM_EDIT_DISPLAY) {
             addButton.setText(R.string.add_to_template);
             detailsCardView.setVisibility(View.GONE);
@@ -692,25 +682,12 @@ public class FontesFragment extends Fragment {
     }
 
     private void showTimePicker(TextView timeTextView) {
-        String tx =  timeTextView.getText().toString();
-        int hour;
-        try {
-            hour = Integer.parseInt(tx.substring(0, 2));
-        } catch (Exception e) {
-            hour = 0;
-        }
-        int min;
-        try {
-            min = Integer.parseInt(tx.substring(3, 5));
-        } catch (Exception e) {
-            min = 0;
-        }
-        int sec;
-        try {
-            sec = Integer.parseInt(tx.substring(6));
-        } catch (Exception e) {
-            sec = 0;
-        }
+        Calendar calendar = Calendar.getInstance();
+        Date time = DateConverter.localTimeStrToDate(timeTextView.getText().toString(), getContext());
+        calendar.setTime(time);
+        int hour = calendar.get(Calendar.HOUR_OF_DAY);
+        int min = calendar.get(Calendar.MINUTE);
+        int sec = calendar.get(Calendar.SECOND);
 
         switch(timeTextView.getId()) {
             case R.id.editTime:
@@ -968,8 +945,8 @@ public class FontesFragment extends Fragment {
 
                 // Set Initial text
                 if (autoTimeCheckBox.isChecked()) {
-                    dateEdit.setText(DateConverter.currentDate());
-                    timeEdit.setText(DateConverter.currentTime());
+                    dateEdit.setText(DateConverter.currentDate(getContext()));
+                    timeEdit.setText(DateConverter.currentTime(getContext()));
                 }
 
                 // Set Table

--- a/app/src/main/java/com/easyfitness/fonte/RecordArrayAdapter.java
+++ b/app/src/main/java/com/easyfitness/fonte/RecordArrayAdapter.java
@@ -200,7 +200,7 @@ public class RecordArrayAdapter extends ArrayAdapter{
         if (mDisplayType == DisplayType.FREE_WORKOUT_DISPLAY || mDisplayType==DisplayType.HISTORY_DISPLAY) {
             viewHolder.ExerciseName.setText(record.getExercise());
             viewHolder.Date.setText(DateConverter.dateToLocalDateStr(record.getDate(), mContext));
-            viewHolder.Time.setText(record.getTime());
+            viewHolder.Time.setText(DateConverter.dateToLocalTimeStr(record.getDate(), mContext));
 
             if (isSeparatorNeeded(position, record.getDate())) {
                 viewHolder.Separator.setText("- " + DateConverter.dateToLocalDateStr(record.getDate(), mContext) + " -");
@@ -290,7 +290,7 @@ public class RecordArrayAdapter extends ArrayAdapter{
                     viewHolder.BtActionFailed.setImageDrawable(ContextCompat.getDrawable(mContext, R.drawable.ic_cross_red_24dp));
                 }
                 viewHolder.Date.setText(DateConverter.dateToLocalDateStr(record.getDate(), mContext));
-                viewHolder.Time.setText(record.getTime());
+                viewHolder.Time.setText(DateConverter.dateToLocalTimeStr(record.getDate(), mContext));
             }
 
             long key = record.getId();
@@ -311,7 +311,6 @@ public class RecordArrayAdapter extends ArrayAdapter{
                         record.setDuration(templateRecord.getDuration());
                         record.setProgramRecordStatus(ProgramRecordStatus.SUCCESS);
                         record.setDate(DateConverter.getNewDate());
-                        record.setTime(DateConverter.currentTime());
                         mDbRecord.updateRecord(record);
                         UpdateRecordTypeUI(record, viewHolder);
                         UpdateValues(record, position, viewHolder);
@@ -345,7 +344,6 @@ public class RecordArrayAdapter extends ArrayAdapter{
                     if (record.getProgramRecordStatus() != ProgramRecordStatus.FAILED) {
                         //Display Editor
                         record.setDate(DateConverter.getNewDate());
-                        record.setTime(DateConverter.currentTime());
                         record.setProgramRecordStatus(ProgramRecordStatus.FAILED);
                         mDbRecord.updateRecord(record);
                         launchCountdown(record);

--- a/app/src/main/java/com/easyfitness/intro/NewProfileFragment.java
+++ b/app/src/main/java/com/easyfitness/intro/NewProfileFragment.java
@@ -90,7 +90,7 @@ public class NewProfileFragment extends SlideFragment {
                     lGender = Gender.OTHER;
                 }
 
-                Profile p = new Profile(mName.getText().toString(), size, DateConverter.editToDate(mBirthday.getText().toString()), lGender);
+                Profile p = new Profile(mName.getText().toString(), size, DateConverter.localDateStrToDate(mBirthday.getText().toString(), getContext()), lGender);
                 // Create the new profil
                 mDbProfils.addProfil(p);
                 //Toast.makeText(getActivity().getBaseContext(), R.string.profileCreated, Toast.LENGTH_SHORT).show();
@@ -109,7 +109,7 @@ public class NewProfileFragment extends SlideFragment {
     private OnDateSetListener dateSet = new OnDateSetListener() {
         @Override
         public void onDateSet(DatePicker view, int year, int month, int day) {
-            mBirthday.setText(DateConverter.dateToString(year, month + 1, day));
+            mBirthday.setText(DateConverter.dateToLocalDateStr(year, month + 1, day, getContext()));
             InputMethodManager inputMethodManager = (InputMethodManager) getActivity().getSystemService(Activity.INPUT_METHOD_SERVICE);
             inputMethodManager.hideSoftInputFromWindow(mBirthday.getWindowToken(), 0);
         }

--- a/app/src/main/java/com/easyfitness/programs/ProgramRunnerFragment.java
+++ b/app/src/main/java/com/easyfitness/programs/ProgramRunnerFragment.java
@@ -127,7 +127,7 @@ public class ProgramRunnerFragment extends Fragment {
             if (mRunningProgram != null) {
                 long runningProgramId = mRunningProgram.getId();
                 long profileId = getProfile().getId();
-                ProgramHistory programHistory = new ProgramHistory(-1, runningProgramId, profileId, ProgramStatus.RUNNING, DateConverter.currentDate(), DateConverter.currentTime(), "", "");
+                ProgramHistory programHistory = new ProgramHistory(-1, runningProgramId, profileId, ProgramStatus.RUNNING, DateConverter.currentDate(getContext()), DateConverter.currentTime(getContext()), "", "");
                 long workoutHistoryId = mDbWorkoutHistory.add(programHistory);
                 mRunningProgramHistory = mDbWorkoutHistory.get(workoutHistoryId);
                 mProgramsSpinner.setEnabled(false);
@@ -155,8 +155,8 @@ public class ProgramRunnerFragment extends Fragment {
 
 
     private void stopProgram(){
-        mRunningProgramHistory.setEndDate(DateConverter.currentDate());
-        mRunningProgramHistory.setEndTime(DateConverter.currentTime());
+        mRunningProgramHistory.setEndDate(DateConverter.currentDate(getContext()));
+        mRunningProgramHistory.setEndTime(DateConverter.currentTime(getContext()));
         mRunningProgramHistory.setStatus(ProgramStatus.CLOSED);
         mDbWorkoutHistory.update(mRunningProgramHistory);
         mRunningProgram=null;

--- a/app/src/main/java/com/easyfitness/utils/DateConverter.java
+++ b/app/src/main/java/com/easyfitness/utils/DateConverter.java
@@ -13,6 +13,7 @@ import java.util.Date;
 import java.util.TimeZone;
 
 import static android.text.format.DateFormat.getDateFormat;
+import static android.text.format.DateFormat.getTimeFormat;
 
 public class DateConverter {
 
@@ -52,6 +53,20 @@ public class DateConverter {
         return date;
     }
 
+    static public Date editToDateTime(String dateText, String timeText) {
+        Date date;
+        try {
+            SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy'T'HH:mm:ss"); // TODO: Locale dependant, change prompt
+            dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+            date = dateFormat.parse(dateText + "T" + timeText);
+        } catch (ParseException e) {
+            e.printStackTrace();
+            date = new Date();
+        }
+
+        return date;
+    }
+
     static public Date localDateStrToDate(String dateStr, Context pContext) {
         Date date;
         try {
@@ -67,7 +82,6 @@ public class DateConverter {
 
     static public String dateToLocalDateStr(Date date, Context pContext) {
         DateFormat dateFormat3 = getDateFormat(pContext.getApplicationContext());
-        dateFormat3.setTimeZone(TimeZone.getTimeZone("GMT"));
         return dateFormat3.format(date);
     }
 
@@ -88,6 +102,30 @@ public class DateConverter {
             date = new Date();
         }
         return date;
+    }
+
+    static public Date DBDateTimeStrToDate(String dateStr, String timeStr) {
+        Date date;
+        try {
+            SimpleDateFormat dateFormat = new SimpleDateFormat(DAOUtils.DATE_FORMAT + "'T'" + DAOUtils.TIME_FORMAT);
+            dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+            date = dateFormat.parse(dateStr + "T" + timeStr);
+        } catch (ParseException e) {
+            e.printStackTrace();
+            date = new Date();
+        }
+        return date;
+    }
+
+    static public String dateToLocalTimeStr(Date date, Context pContext) {
+        DateFormat dateFormat3 = getTimeFormat(pContext.getApplicationContext());
+        return dateFormat3.format(date);
+    }
+
+    static public String dateToDBTimeStr(Date date) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(DAOUtils.TIME_FORMAT);
+        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+        return dateFormat.format(date);
     }
 
     static public String currentTime() {
@@ -137,6 +175,13 @@ public class DateConverter {
     static public Date dateToDate(int year, int month, int day) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(year, month, day);
+
+        return calendar.getTime();
+    }
+
+    static public Date dateToDate(int year, int month, int day, int hour, int minute, int second) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(year, month, day, hour, minute, second);
 
         return calendar.getTime();
     }

--- a/app/src/main/java/com/easyfitness/utils/DateConverter.java
+++ b/app/src/main/java/com/easyfitness/utils/DateConverter.java
@@ -21,8 +21,10 @@ public class DateConverter {
     public DateConverter() {
     }
 
-    static public double nbDays(double millisecondes) {
-        return (int) (millisecondes / MILLISECONDINDAY);
+    static public double nbDays(Date date) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+        return ((calendar.getTimeInMillis() + calendar.get(Calendar.ZONE_OFFSET) + calendar.get(Calendar.DST_OFFSET)) / MILLISECONDINDAY);
     }
 
     static public double nbMinutes(double millisecondes) {

--- a/app/src/main/java/com/easyfitness/utils/DateConverter.java
+++ b/app/src/main/java/com/easyfitness/utils/DateConverter.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import com.easyfitness.DAO.DAOUtils;
 
 import java.text.DateFormat;
-import java.text.DecimalFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -39,26 +38,13 @@ public class DateConverter {
         return new Date();
     }
 
-    static public Date editToDate(String editText) {
+    static public Date localDateTimeStrToDateTime(String dateText, String timeText, Context pContext) {
         Date date;
         try {
-            SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy");
-            dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-            date = dateFormat.parse(editText);
-        } catch (ParseException e) {
-            e.printStackTrace();
-            date = new Date();
-        }
-
-        return date;
-    }
-
-    static public Date editToDateTime(String dateText, String timeText) {
-        Date date;
-        try {
-            SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy'T'HH:mm:ss"); // TODO: Locale dependant, change prompt
-            dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-            date = dateFormat.parse(dateText + "T" + timeText);
+            String dateFormat = ((SimpleDateFormat)getDateFormat(pContext.getApplicationContext())).toLocalizedPattern();
+            String timeFormat = ((SimpleDateFormat)getTimeFormat(pContext.getApplicationContext())).toLocalizedPattern();
+            SimpleDateFormat dateTimeFormat = new SimpleDateFormat(dateFormat + "'T'" + timeFormat);
+            date = dateTimeFormat.parse(dateText + "T" + timeText);
         } catch (ParseException e) {
             e.printStackTrace();
             date = new Date();
@@ -71,8 +57,19 @@ public class DateConverter {
         Date date;
         try {
             DateFormat dateFormat = getDateFormat(pContext.getApplicationContext());
-            dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
             date = dateFormat.parse(dateStr);
+        } catch (ParseException e) {
+            e.printStackTrace();
+            date = new Date();
+        }
+        return date;
+    }
+
+    static public Date localTimeStrToDate(String timeStr, Context pContext) {
+        Date date;
+        try {
+            DateFormat timeFormat = getTimeFormat(pContext.getApplicationContext());
+            date = timeFormat.parse(timeStr);
         } catch (ParseException e) {
             e.printStackTrace();
             date = new Date();
@@ -85,9 +82,15 @@ public class DateConverter {
         return dateFormat3.format(date);
     }
 
-    static public String dateToDBDateStr(Date date) {
+    static public String dateTimeToDBDateStr(Date date) {
         SimpleDateFormat dateFormat = new SimpleDateFormat(DAOUtils.DATE_FORMAT);
         dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+        return dateFormat.format(date);
+    }
+
+    static public String dateToDBDateStr(Date date) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(DAOUtils.DATE_FORMAT);
+        // No time is given, use local time
         return dateFormat.format(date);
     }
 
@@ -95,7 +98,7 @@ public class DateConverter {
         Date date;
         try {
             SimpleDateFormat dateFormat = new SimpleDateFormat(DAOUtils.DATE_FORMAT);
-            dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+            // No time is given, use local time
             date = dateFormat.parse(dateStr);
         } catch (ParseException e) {
             e.printStackTrace();
@@ -122,38 +125,22 @@ public class DateConverter {
         return dateFormat3.format(date);
     }
 
-    static public String dateToDBTimeStr(Date date) {
+    static public String dateTimeToDBTimeStr(Date date) {
         SimpleDateFormat dateFormat = new SimpleDateFormat(DAOUtils.TIME_FORMAT);
         dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
         return dateFormat.format(date);
     }
 
-    static public String currentTime() {
+    static public String currentTime(Context pContext) {
         //Rajoute le moment du dernier ajout dans le bouton Add
-        Calendar calendar = Calendar.getInstance();
-        int hours = calendar.get(Calendar.HOUR_OF_DAY);
-        int minutes = calendar.get(Calendar.MINUTE);
-        int seconds = calendar.get(Calendar.SECOND);
-
-        DecimalFormat df = new DecimalFormat("00");
-        return df.format(hours) + ":" + df.format(minutes) + ":" + df.format(seconds);
+        Date date = new Date();
+        return dateToLocalTimeStr(date, pContext);
     }
 
-    static public String currentDate() {
+    static public String currentDate(Context pContext) {
         //Rajoute le moment du dernier ajout dans le bouton Add
-        Calendar calendar = Calendar.getInstance();
-        int day = calendar.get(Calendar.DAY_OF_MONTH);
-        int month = calendar.get(Calendar.MONTH);
-        int year = calendar.get(Calendar.YEAR);
-
-        DecimalFormat df = new DecimalFormat("00");
-        return df.format(day) + "/" + df.format(month + 1) + "/" + df.format(year);
-    }
-
-    static public String dateToString(int year, int month, int day) {
-        // Do something with the date chosen by the user
-        DecimalFormat df = new DecimalFormat("00");
-        return df.format(day) + "/" + df.format(month) + "/" + df.format(year);
+        Date date = new Date();
+        return dateToLocalDateStr(date, pContext);
     }
 
     /**
@@ -182,6 +169,15 @@ public class DateConverter {
     static public Date dateToDate(int year, int month, int day, int hour, int minute, int second) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(year, month, day, hour, minute, second);
+
+        return calendar.getTime();
+    }
+
+    static public Date timeToDate(int hour, int minute, int second) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(Calendar.HOUR_OF_DAY, hour);
+        calendar.set(Calendar.MINUTE, minute);
+        calendar.set(Calendar.SECOND, second);
 
         return calendar.getTime();
     }


### PR DESCRIPTION
Changes:

* Combines record date and time, fixes issue when local date is different from GMT date
* Date-only objects, such as body recordings, birthday, etc, are always treated as local date, no timezone conversion
* All date and time inputs and outputs use locale strings, follow system preferences on 12/24 hour
* History date filtering uses local time, records sorted by date and time
* All graphs use local time for dates

Fixes #170 