### PR TITLE
Added feature to calculate BMR and daily calories based on activity l…

### DIFF
--- a/app/src/main/java/com/easyfitness/WeightFragment.java
+++ b/app/src/main/java/com/easyfitness/WeightFragment.java
@@ -1,6 +1,8 @@
 package com.easyfitness;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -8,15 +10,19 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.ImageButton;
+import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.preference.PreferenceManager;
 
 import com.easyfitness.DAO.DAOProfile;
 import com.easyfitness.DAO.DAOProfileWeight;
@@ -39,9 +45,17 @@ import com.github.mikephil.charting.data.Entry;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.onurkaganaldemir.ktoastlib.KToast;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.text.SimpleDateFormat;
 
 import cn.pedant.SweetAlert.SweetAlertDialog;
 
@@ -101,6 +115,22 @@ public class WeightFragment extends Fragment {
                         .showCancelButton(true)
                         .show();
                 break;
+            case R.id.bmrHelp:
+                new SweetAlertDialog(getContext(), SweetAlertDialog.NORMAL_TYPE)
+                        .setTitleText(R.string.bmrLabel)
+                        .setContentText(getString(R.string.bmr_dialog_title))
+                        .setConfirmText(getResources().getText(android.R.string.ok).toString())
+                        .showCancelButton(true)
+                        .show();
+                break;
+            case R.id.dailyCalorieHelp:
+                new SweetAlertDialog(getContext(), SweetAlertDialog.NORMAL_TYPE)
+                        .setTitleText(R.string.daily_calorie_alert)
+                        .setContentText(getString(R.string.daily_calorie_alert_body))
+                        .setConfirmText(getResources().getText(android.R.string.ok).toString())
+                        .showCancelButton(true)
+                        .show();
+                break;
             case R.id.rfmHelp:
                 new SweetAlertDialog(getContext(), SweetAlertDialog.NORMAL_TYPE)
                         .setTitleText(R.string.RFM_dialog_title)
@@ -112,6 +142,7 @@ public class WeightFragment extends Fragment {
                 break;
         }
     };
+    double calorieMultiplier; //Daily calorie multiplier
     MainActivity mActivity = null;
     private TextView weightEdit = null;
     private TextView fatEdit = null;
@@ -122,6 +153,9 @@ public class WeightFragment extends Fragment {
     private TextView imcRank = null;
     private TextView ffmiText = null;
     private TextView ffmiRank = null;
+    private TextView bmrCals = null;
+    private TextView bmrText = null;
+    private TextView dailyCalorieValue = null;
     private TextView rfmText = null;
     private TextView rfmRank = null;
     private LineChart mWeightLineChart;
@@ -274,7 +308,7 @@ public class WeightFragment extends Fragment {
                 Value newWeightValue = null;
                 // Find the weight value if we need it as the baseline
                 for (Value newValue : newValues) {
-                    if(newValue.getId().equals(String.valueOf(weightBodyPart.getId()))){
+                    if (newValue.getId().equals(String.valueOf(weightBodyPart.getId()))) {
                         newWeightValue = newValue;
                         break;
                     }
@@ -294,13 +328,13 @@ public class WeightFragment extends Fragment {
                     // If the unit is not in percent and it is a percentage measurement convert it
                     if (newValue.getUnit() != Unit.PERCENTAGE && (bodyPartId == fatBodyPart.getId() || bodyPartId == musclesBodyPart.getId() || bodyPartId == waterBodyPart.getId())) {
                         // Convert them to the same unit if necessary
-                        if(newValue.getUnit() != newWeightValue.getUnit()){
+                        if (newValue.getUnit() != newWeightValue.getUnit()) {
                             newValue.setValue(UnitConverter.weightConverter(newValue.getValue(), newValue.getUnit(), newWeightValue.getUnit()));
                             newValue.setUnit(newWeightValue.getUnit());
                         }
 
                         // Convert absolute value to percentage
-                        newValue.setValue((newValue.getValue() / newWeightValue.getValue())*100);
+                        newValue.setValue((newValue.getValue() / newWeightValue.getValue()) * 100);
                         newValue.setUnit(Unit.PERCENTAGE);
                     }
                     mDbBodyMeasure.addBodyMeasure(date, bodyPartId, newValue, profileId);
@@ -350,11 +384,17 @@ public class WeightFragment extends Fragment {
         imcRank = view.findViewById(R.id.imcViewText);
         ffmiText = view.findViewById(R.id.ffmiValue);
         ffmiRank = view.findViewById(R.id.ffmiViewText);
+        bmrCals = view.findViewById(R.id.bmrValue);
+        bmrText = view.findViewById(R.id.bmrViewText);
+        dailyCalorieValue = view.findViewById(R.id.dailyCalorieValue);
         rfmText = view.findViewById(R.id.rfmValue);
         rfmRank = view.findViewById(R.id.rfmViewText);
+        Spinner spinner = view.findViewById(R.id.activityLevelSpinner);
 
         ImageButton ffmiHelpButton = view.findViewById(R.id.ffmiHelp);
         ImageButton imcHelpButton = view.findViewById(R.id.imcHelp);
+        ImageButton bmrHelpButton = view.findViewById(R.id.bmrHelp);
+        ImageButton dailyCalorieHelpButton = view.findViewById(R.id.dailyCalorieHelp);
         ImageButton rfmHelpButton = view.findViewById(R.id.rfmHelp);
 
         FloatingActionButton addAllButton = view.findViewById(R.id.addAllWeightEntries);
@@ -368,6 +408,8 @@ public class WeightFragment extends Fragment {
         addAllButton.setOnClickListener(mOnAddAllEntriesClickListener);
         imcHelpButton.setOnClickListener(showHelp);
         ffmiHelpButton.setOnClickListener(showHelp);
+        bmrHelpButton.setOnClickListener(showHelp);
+        dailyCalorieHelpButton.setOnClickListener(showHelp);
         rfmHelpButton.setOnClickListener(showHelp);
         weightDetailsButton.setOnClickListener(showDetailsFragment);
         fatDetailsButton.setOnClickListener(showDetailsFragment);
@@ -409,6 +451,65 @@ public class WeightFragment extends Fragment {
         appViMo.getProfile().observe(getViewLifecycleOwner(), profile -> {
             // Update the UI, in this case, a TextView.
             refreshData();
+        });
+
+        //Implementation for activity level spinner
+        ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(requireActivity(),
+                R.array.activity_level, android.R.layout.simple_spinner_item);
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spinner.setAdapter(adapter);
+
+        //Setup shared preferences to save spinner selection
+        SharedPreferences SP = PreferenceManager.getDefaultSharedPreferences(getActivity().getBaseContext());
+        int spinnerValue = SP.getInt("userSpinner", -1);
+        if (spinnerValue != -1) {
+            spinner.setSelection(spinnerValue);
+        }
+
+
+        spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            public void onItemSelected(AdapterView<?> parent, View view,
+                                       int position, long id) {
+
+                // On selecting a spinner item
+                String item = parent.getItemAtPosition(position).toString();
+                if (item.equals(getResources().getString(R.string.sedentary))) {
+                    calorieMultiplier = 1.2;
+                    refreshData();
+                } else if (item.equals(getResources().getString(R.string.moderate))) {
+                    calorieMultiplier = 1.375;
+                    refreshData();
+                } else if (item.equals(getResources().getString(R.string.active))) {
+                    calorieMultiplier = 1.465;
+                    refreshData();
+                } else if (item.equals(getResources().getString(R.string.daily_exercise))) {
+                    calorieMultiplier = 1.55;
+                    refreshData();
+                } else if (item.equals(getResources().getString(R.string.intense))) {
+                    calorieMultiplier = 1.725;
+                    refreshData();
+                } else if (item.equals(getResources().getString(R.string.very_intense))) {
+                    calorieMultiplier = 1.9;
+                    refreshData();
+                } else {
+                    calorieMultiplier = 1.2;
+                    refreshData();
+                }
+
+                //Saving selected activity level to shared preferences
+                int userChoice = spinner.getSelectedItemPosition();
+                SharedPreferences SP = PreferenceManager.getDefaultSharedPreferences(getActivity().getBaseContext());
+                SharedPreferences.Editor prefEditor = SP.edit();
+                prefEditor.putInt("userSpinner", userChoice);
+                prefEditor.commit();
+
+
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+
+            }
         });
 
         return view;
@@ -683,6 +784,37 @@ public class WeightFragment extends Fragment {
         }
     }
 
+    private double calculateBmrMenMifflin(float weight, float size) {
+        /**
+         *Mifflin-St Jeor Equation
+         * For men: BMR = 10W + 6.25H - 5A + 5
+         **/
+
+        int birthYear = getProfile().getBirthday().toInstant().atZone(ZoneId.systemDefault()).toLocalDate().getYear();
+        int age = Calendar.getInstance().get(Calendar.YEAR) - birthYear;
+
+        return (10 * weight) + (6.25 * size) - (5 * age) + 5;
+    }
+
+    private double calculateBmrWomenMifflin(float weight, float size) {
+        /**
+         *Mifflin-St Jeor Equation
+         * For women: BMR = 10W + 6.25H - 5A - 161
+         **/
+        int birthYear = getProfile().getBirthday().toInstant().atZone(ZoneId.systemDefault()).toLocalDate().getYear();
+        int age = Calendar.getInstance().get(Calendar.YEAR) - birthYear;
+
+        return (10 * weight) + (6.25 * size) - (5 * age) - 161;
+    }
+
+    private double calculateBmrKatch(float bodyFat, float weight) {
+        /**
+         * Katch-McArdle Formula: BMR = 370 + 21.6(1 - F)W
+         **/
+
+        return Math.round(370 + (21.6 * (1 - (bodyFat / 100)) * weight));
+    }
+
     /**
      * Get a Value object which uses the data from the last measure if available
      *
@@ -725,6 +857,7 @@ public class WeightFragment extends Fragment {
                                 UnitConverter.sizeConverter(lastSizeValue.getBodyMeasure().getValue(), lastSizeValue.getBodyMeasure().getUnit(), Unit.CM));
                         imcText.setText(String.format("%.1f", imcValue));
                         imcRank.setText(getImcText(imcValue));
+
                         if (lastFatValue != null) {
                             double ffmiValue = calculateFfmi(UnitConverter.weightConverter(lastWeightValue.getBodyMeasure().getValue(), lastWeightValue.getBodyMeasure().getUnit(), Unit.KG),
                                     UnitConverter.sizeConverter(lastSizeValue.getBodyMeasure().getValue(), lastSizeValue.getBodyMeasure().getUnit(), Unit.CM),
@@ -737,19 +870,53 @@ public class WeightFragment extends Fragment {
                             else if (getProfile().getGender() == Gender.OTHER)
                                 ffmiRank.setText(getFfmiTextForMen(ffmiValue));
                             else
-                                ffmiRank.setText("no gender defined");
+                                ffmiRank.setText(R.string.no_gender_defined);
                         } else {
                             ffmiText.setText("-");
                             ffmiRank.setText(R.string.no_fat_available);
                         }
 
                     }
+
+                    //update BMR
+                    if (lastFatValue != null && 0 <= lastFatValue.getBodyMeasure().getValue() && lastFatValue.getBodyMeasure().getValue() <= 15) {
+                        bmrCals.setText((String.format("%.0f", calculateBmrKatch(lastFatValue.getBodyMeasure().getValue(), UnitConverter.weightConverter(lastWeightValue.getBodyMeasure().getValue(), lastWeightValue.getBodyMeasure().getUnit(), Unit.KG)))));
+                        bmrText.setText(R.string.bmrCalories);
+                        dailyCalorieValue.setText((String.format("%.0f", calculateBmrKatch(lastFatValue.getBodyMeasure().getValue(), UnitConverter.weightConverter(lastWeightValue.getBodyMeasure().getValue(), lastWeightValue.getBodyMeasure().getUnit(), Unit.KG)) * calorieMultiplier)));
+                    } else if (lastSizeValue != null) {
+                        if (getProfile().getGender() == Gender.MALE) {
+                            bmrCals.setText(String.format("%.0f", calculateBmrMenMifflin(UnitConverter.weightConverter(lastWeightValue.getBodyMeasure().getValue(), lastWeightValue.getBodyMeasure().getUnit(), Unit.KG),
+                                    UnitConverter.sizeConverter(lastSizeValue.getBodyMeasure().getValue(), lastSizeValue.getBodyMeasure().getUnit(), Unit.CM))));
+                            bmrText.setText(R.string.bmrCalories);
+                            dailyCalorieValue.setText(String.format("%.0f", calculateBmrMenMifflin(UnitConverter.weightConverter(lastWeightValue.getBodyMeasure().getValue(), lastWeightValue.getBodyMeasure().getUnit(), Unit.KG),
+                                    UnitConverter.sizeConverter(lastSizeValue.getBodyMeasure().getValue(), lastSizeValue.getBodyMeasure().getUnit(), Unit.CM)) * calorieMultiplier));
+                        } else if (getProfile().getGender() == Gender.FEMALE) {
+                            bmrCals.setText(String.format("%.0f", calculateBmrWomenMifflin(UnitConverter.weightConverter(lastWeightValue.getBodyMeasure().getValue(), lastWeightValue.getBodyMeasure().getUnit(), Unit.KG),
+                                    UnitConverter.sizeConverter(lastSizeValue.getBodyMeasure().getValue(), lastSizeValue.getBodyMeasure().getUnit(), Unit.CM))));
+                            bmrText.setText(R.string.bmrCalories);
+                            dailyCalorieValue.setText(String.format("%.0f", calculateBmrWomenMifflin(UnitConverter.weightConverter(lastWeightValue.getBodyMeasure().getValue(), lastWeightValue.getBodyMeasure().getUnit(), Unit.KG),
+                                    UnitConverter.sizeConverter(lastSizeValue.getBodyMeasure().getValue(), lastSizeValue.getBodyMeasure().getUnit(), Unit.CM)) * calorieMultiplier));
+                        } else {
+                            bmrCals.setText(String.format("%.0f", calculateBmrMenMifflin(UnitConverter.weightConverter(lastWeightValue.getBodyMeasure().getValue(), lastWeightValue.getBodyMeasure().getUnit(), Unit.KG),
+                                    UnitConverter.sizeConverter(lastSizeValue.getBodyMeasure().getValue(), lastSizeValue.getBodyMeasure().getUnit(), Unit.CM))));
+                            bmrText.setText(R.string.bmrCalories);
+                            dailyCalorieValue.setText(String.format("%.0f", calculateBmrMenMifflin(UnitConverter.weightConverter(lastWeightValue.getBodyMeasure().getValue(), lastWeightValue.getBodyMeasure().getUnit(), Unit.KG),
+                                    UnitConverter.sizeConverter(lastSizeValue.getBodyMeasure().getValue(), lastSizeValue.getBodyMeasure().getUnit(), Unit.CM)) * calorieMultiplier));
+                        }
+                    } else {
+                        bmrText.setText(R.string.no_size_available);
+                        dailyCalorieValue.setText("-");
+                    }
+
                 } else {
                     weightEdit.setText("-");
                     imcText.setText("-");
                     imcRank.setText(R.string.no_weight_available);
                     ffmiText.setText("-");
                     ffmiRank.setText(R.string.no_weight_available);
+                    bmrCals.setText("-");
+                    bmrText.setText(R.string.no_weight_available);
+                    dailyCalorieValue.setText("-");
                 }
 
                 if (lastWaterValue != null) {
@@ -783,6 +950,7 @@ public class WeightFragment extends Fragment {
             }
         }
     }
+
 
     private Profile getProfile() {
         return appViMo.getProfile().getValue();

--- a/app/src/main/res/layout/tab_weight.xml
+++ b/app/src/main/res/layout/tab_weight.xml
@@ -370,6 +370,69 @@
 
                         <TableRow
                             android:layout_width="match_parent"
+                            android:layout_height="wrap_content">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/bmrLabel"
+                                android:textSize="20sp" />
+
+                            <TextView
+                                android:id="@+id/bmrValue"
+                                style="@style/WeightIndexStyle"
+                                tools:text="20" />
+
+                            <TextView
+                                android:id="@+id/bmrViewText"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:gravity="center"
+                                android:textSize="20sp"
+                                android:textStyle="italic"
+                                tools:text="normal" />
+
+                            <ImageButton
+                                android:id="@+id/bmrHelp"
+                                style="@style/InfoButton"
+                                app:srcCompat="@drawable/ic_help_outline" />
+
+                        </TableRow>
+
+                        <TableRow
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/daily_calorie_label"
+                                android:textSize="20sp" />
+
+                            <TextView
+                                android:id="@+id/dailyCalorieValue"
+                                style="@style/WeightIndexStyle"
+                                tools:text="20" />
+
+                            <Spinner
+                                android:id="@+id/activityLevelSpinner"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:gravity="center"
+                                android:paddingLeft="25pt"
+                                android:textSize="20sp"
+                                android:textStyle="italic"
+                                tools:text="normal" />
+
+                            <ImageButton
+                                android:id="@+id/dailyCalorieHelp"
+                                style="@style/InfoButton"
+                                app:srcCompat="@drawable/ic_help_outline" />
+
+                        </TableRow>
+
+                        <TableRow
+                            android:layout_width="match_parent"
                             android:layout_height="match_parent"
                             android:visibility="gone"
                             tools:visibility="gone">
@@ -450,20 +513,20 @@
                 android:layout_height="76dp" />
         </LinearLayout>
     </ScrollView>
+
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/addAllWeightEntries"
         android:layout_width="56dp"
         android:layout_height="56dp"
-        android:src="@drawable/ic_add_multiple"
-        android:contentDescription="@string/AddLabel"
-        android:gravity="bottom"
         android:layout_alignParentEnd="true"
         android:layout_alignParentBottom="true"
         android:layout_margin="10dp"
         android:backgroundTint="@color/toolbar_background"
-        app:fabSize="normal"
+        android:contentDescription="@string/AddLabel"
+        android:gravity="bottom"
+        android:src="@drawable/ic_add_multiple"
         app:borderWidth="0dp"
-        />
+        app:fabSize="normal" />
 
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -329,7 +329,7 @@
     <string name="otherGender">Other</string>
     <string name="enter_gender_here">Enter gender</string>
     <string name="gender">Gender</string>
-    <string name="no_size_available">no size available</string>
+    <string name="no_size_available">no height available</string>
     <string name="no_weight_available">no weight available</string>
     <string name="BMI_dialog_title">Body Mass Index (BMI)</string>
     <string name="BMI_formula">BMI = weight(kg) / height(m)²</string>
@@ -342,7 +342,39 @@
     <string name="ffmiLabel">FFMI</string>
     <string name="FFMI_dialog_title">Fat-free mass index (FFMI)</string>
     <string name="FFMI_formula">FFMI [kg/m2] = weight [kg] × (1 − (body fat [%] / 100)) / (height [m])²</string>
+    <string name="bmrLabel">BMR</string>
+    <string name="bmr_dialog_title">
+        Calculated using the Mifflin-St Jeor equation. For individuals at 15% bodyfat and under, the Katch-McArdle formula
+        is used which tends to be more accurate for individuals who are leaner, and know their body fat percentage. For greater
+        accuracy in calculating your BMR, it is recommended to enter your birthday, height, weight, and body fat percentage.
+        This will help the app determine which formula to use when performing this calculation.
+    </string>
+    <string name="bmrCalories">calories/day</string>
+    <string name="daily_calorie_label">Daily Cals</string>
+    <string name="daily_calorie_alert">Daily Calorie Needs</string>
+    <string name="daily_calorie_alert_body">
+        An estimate of the calories required daily to maintain your current weight. This calculation uses your BMR, and
+        activity level to produce a recommendation. For more accurate results, it is recommended to enter your weight,
+        height, body fat percentage, and birthday into the app. Remember that this value is an estimate, and that
+        individual calorie needs will vary.
+    </string>
+    <string name="sedentary">Sedentary</string>
+    <string name="moderate">Moderate</string>
+    <string name="active">Active</string>
+    <string name="daily_exercise">Daily Exercise</string>
+    <string name="intense">Intense</string>
+    <string name="very_intense">Very Intense</string>
+    <string-array name="activity_level">
+        <item>@string/sedentary</item>
+        <item>@string/moderate</item>
+        <item>@string/active</item>
+        <item>@string/daily_exercise</item>
+        <item>@string/intense</item>
+        <item>@string/very_intense</item>
+    </string-array>
     <string name="no_fat_available">no fat available</string>
+    <string name="no_gender_defined">no gender defined</string>
+    <string name="insufficient_data">insufficient data</string>
     <string name="indexLabel">Index</string>
     <string name="what_type_of_exercise">Exercise type?</string>
     <string name="exercise_type">Exercise Type:</string>


### PR DESCRIPTION
This patch addresses issue #238.

The following features were added:

1. In Weight Track -> Index, the BMR for the user is calculated based on two formulas, the Mifflin-St Jeor equation, and the Katch-McArdle formula. The latter formula is said to be more accurate for individuals who are leaner. For those with body fat levels equal to or lower than 15%, the app uses the Katch-McArdle Formula to calculate BMR. When body fat is greater than 15%, the Mifflin-St Jeor equation is utilized. The body fat cutoff value can be changed.

2. Estimated daily calories are now provided in Weight Track -> Index as well. This calculation is based off the user's BMR. A spinner allows the user to select their activity level. This selected activity level is saved even when the app is closed. Depending on which activity level is selected, a different multiplier is used against the BMR to produce the daily calorie value. If the user decides to change the activity level, the daily calorie recommendation will be updated in real-time. 

The equations used to perform these calculations can be referenced here: https://www.calculator.net/bmr-calculator.html

Screenshots have been provided for more info. 

Please let me know if you have any questions/comments. 

Thanks
![Screenshot_1644030692](https://user-images.githubusercontent.com/72053963/152627474-ebf8664b-edc3-4e46-974d-b3c4991c8976.png)
![Screenshot_1644030701](https://user-images.githubusercontent.com/72053963/152627476-848df0a0-8e56-4b67-9ddf-de1c432c3e6a.png)
![Screenshot_1644030718](https://user-images.githubusercontent.com/72053963/152627477-08657143-2b65-4c85-b47b-c2ac825fb647.png)
![Screenshot_1644030722](https://user-images.githubusercontent.com/72053963/152627478-f502b32f-00e6-49b5-9c53-957759ab29b9.png)

