### PR TITLE
Fix min/max not shown for free_records

### DIFF
--- a/app/src/main/java/com/easyfitness/DAO/record/DAOFonte.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAOFonte.java
@@ -288,11 +288,8 @@ public class DAOFonte extends DAORecord {
                 + " AND " + RECORD_TYPE + "!=" + RecordType.PROGRAM_TEMPLATE.ordinal();
         mCursor = db.rawQuery(selectQuery, null);
 
-        // looping through all rows and adding to list
         if (mCursor.moveToFirst()) {
-            do {
-                w = new Weight(mCursor.getFloat(0), WeightUnit.fromInteger(mCursor.getInt(1)));
-            } while (mCursor.moveToNext());
+            w = new Weight(mCursor.getFloat(0), WeightUnit.fromInteger(mCursor.getInt(1)));
         }
         close();
 
@@ -316,11 +313,8 @@ public class DAOFonte extends DAORecord {
                 + " AND " + RECORD_TYPE + "!=" + RecordType.PROGRAM_TEMPLATE.ordinal();
         mCursor = db.rawQuery(selectQuery, null);
 
-        // looping through all rows and adding to list
         if (mCursor.moveToFirst()) {
-            do {
-                w = new Weight(mCursor.getFloat(0), WeightUnit.fromInteger(mCursor.getInt(1)));
-            } while (mCursor.moveToNext());
+           w = new Weight(mCursor.getFloat(0), WeightUnit.fromInteger(mCursor.getInt(1)));
         }
         close();
 

--- a/app/src/main/java/com/easyfitness/DAO/record/DAOFonte.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAOFonte.java
@@ -284,7 +284,8 @@ public class DAOFonte extends DAORecord {
         // Select All Machines
         String selectQuery = "SELECT MAX(" + WEIGHT + "), " + WEIGHT_UNIT + " FROM " + TABLE_NAME
                 + " WHERE " + PROFILE_KEY + "=" + p.getId() + " AND " + EXERCISE_KEY + "=" + m.getId()
-                + " AND " + TEMPLATE_RECORD_STATUS + "<" + ProgramRecordStatus.PENDING.ordinal()
+                + " AND ( " + TEMPLATE_RECORD_STATUS + "<" + ProgramRecordStatus.SUCCESS.ordinal()
+                + " OR "+ TEMPLATE_RECORD_STATUS + "=" + ProgramRecordStatus.NONE.ordinal() + ")"
                 + " AND " + RECORD_TYPE + "!=" + RecordType.PROGRAM_TEMPLATE.ordinal();
         mCursor = db.rawQuery(selectQuery, null);
 
@@ -309,7 +310,8 @@ public class DAOFonte extends DAORecord {
         // Select All Machines
         String selectQuery = "SELECT MIN(" + WEIGHT + "), " + WEIGHT_UNIT + " FROM " + TABLE_NAME
                 + " WHERE " + PROFILE_KEY + "=" + p.getId() + " AND " + EXERCISE_KEY + "=" + m.getId()
-                + " AND " + TEMPLATE_RECORD_STATUS + "<" + ProgramRecordStatus.PENDING.ordinal()
+                + " AND ( " + TEMPLATE_RECORD_STATUS + "<" + ProgramRecordStatus.SUCCESS.ordinal()
+                + " OR "+ TEMPLATE_RECORD_STATUS + "=" + ProgramRecordStatus.NONE.ordinal() + ")"
                 + " AND " + RECORD_TYPE + "!=" + RecordType.PROGRAM_TEMPLATE.ordinal();
         mCursor = db.rawQuery(selectQuery, null);
 

--- a/app/src/main/java/com/easyfitness/DAO/record/DAOStatic.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAOStatic.java
@@ -242,7 +242,8 @@ public class DAOStatic extends DAORecord {
         // Select All Machines
         String selectQuery = "SELECT MAX(" + WEIGHT + "), " + WEIGHT_UNIT + " FROM " + TABLE_NAME
                 + " WHERE " + PROFILE_KEY + "=" + p.getId() + " AND " + EXERCISE_KEY + "=" + m.getId()
-                + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
+                + " AND ( " + TEMPLATE_RECORD_STATUS + "<" + ProgramRecordStatus.SUCCESS.ordinal()
+                + " OR "+ TEMPLATE_RECORD_STATUS + "=" + ProgramRecordStatus.NONE.ordinal() + ")"
                 + " AND " + RECORD_TYPE + "!=" + RecordType.PROGRAM_TEMPLATE.ordinal();
         mCursor = db.rawQuery(selectQuery, null);
 
@@ -268,7 +269,8 @@ public class DAOStatic extends DAORecord {
         // Select All Machines
         String selectQuery = "SELECT MIN(" + WEIGHT + "), " + WEIGHT_UNIT + " FROM " + TABLE_NAME
                 + " WHERE " + PROFILE_KEY + "=" + p.getId() + " AND " + EXERCISE_KEY + "=" + m.getId()
-                + " AND " + TEMPLATE_RECORD_STATUS + "!=" + ProgramRecordStatus.PENDING.ordinal()
+                + " AND ( " + TEMPLATE_RECORD_STATUS + "<" + ProgramRecordStatus.SUCCESS.ordinal()
+                + " OR "+ TEMPLATE_RECORD_STATUS + "=" + ProgramRecordStatus.NONE.ordinal() + ")"
                 + " AND " + RECORD_TYPE + "!=" + RecordType.PROGRAM_TEMPLATE.ordinal();
         mCursor = db.rawQuery(selectQuery, null);
 

--- a/app/src/main/java/com/easyfitness/DAO/record/DAOStatic.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAOStatic.java
@@ -248,9 +248,7 @@ public class DAOStatic extends DAORecord {
 
         // looping through all rows and adding to list
         if (mCursor.moveToFirst()) {
-            do {
-                w = new Weight(mCursor.getFloat(0), WeightUnit.fromInteger(mCursor.getInt(1)));
-            } while (mCursor.moveToNext());
+            w = new Weight(mCursor.getFloat(0), WeightUnit.fromInteger(mCursor.getInt(1)));
         }
         close();
 
@@ -276,9 +274,7 @@ public class DAOStatic extends DAORecord {
 
         // looping through all rows and adding to list
         if (mCursor.moveToFirst()) {
-            do {
-                w = new Weight(mCursor.getFloat(0), WeightUnit.fromInteger(mCursor.getInt(1)));
-            } while (mCursor.moveToNext());
+            w = new Weight(mCursor.getFloat(0), WeightUnit.fromInteger(mCursor.getInt(1)));
         }
         close();
 


### PR DESCRIPTION
Min/Max value is not shown in the overview for free_records because of TEMPLATE_RECORD_STATUS beeing NONE.

![Screenshot_20240209-181815_1_1](https://github.com/brodeurlv/fastnfitness/assets/32903896/5b04d83b-0f00-43c3-b71f-d330b2ea768c)

This fixes the getMin and getMax SQL querry and removes an unused loop.