### PR TITLE
Fix typo in progress_images string value

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -458,7 +458,7 @@
     <string name="also_update_program">Also update program</string>
     <string name="not_done">Not done</string>
     <string name="license">License:</string>
-    <string name="progress_images">Progess Images</string>
+    <string name="progress_images">Progress Images</string>
     <string name="newer_image">newer</string>
     <string name="older_image">older</string>
     <string name="import_unknow_file_extensions">Unknown file extension can\'t import</string>


### PR DESCRIPTION
Fixing the typo in the value of progress_images string. It currently says "Progess Images".
![share_2397431372049681876](https://github.com/user-attachments/assets/5eb19c91-e101-40cb-a6f1-0c6d96316097)
