### PR TITLE
fix: make exercise rename actually target template records (See #265)

### DIFF
--- a/app/src/main/java/com/easyfitness/DAO/record/DAORecord.java
+++ b/app/src/main/java/com/easyfitness/DAO/record/DAORecord.java
@@ -674,7 +674,7 @@ public class DAORecord extends DAOBase {
         return getRecordsList(selectQuery, new String[]{pMachine});
     }
 
-    public List<Record> getAllRecordByMachineIdArray(Profile pProfile, long pMachineId, int pNbRecords) {
+    public List<Record> getAllRecordByMachineIdArray(long pMachineId, int pNbRecords) {
         String mTop;
         if (pNbRecords == -1)
             mTop = "";
@@ -684,7 +684,6 @@ public class DAORecord extends DAOBase {
         // Select All Query
         String selectQuery = "SELECT * FROM " + TABLE_NAME
                 + " WHERE " + EXERCISE_KEY + " = " + pMachineId
-                + " AND " + PROFILE_KEY + "=" + pProfile.getId()
                 + " ORDER BY " + DATE_TIME + " DESC," + KEY + " DESC" + mTop;
 
         // return value list
@@ -692,8 +691,8 @@ public class DAORecord extends DAOBase {
     }
 
     // Get all record for one Machine
-    public List<Record> getAllRecordByMachineIdArray(Profile pProfile, long pMachineId) {
-        return getAllRecordByMachineIdArray(pProfile, pMachineId, -1);
+    public List<Record> getAllRecordByMachineIdArray(long pMachineId) {
+        return getAllRecordByMachineIdArray(pMachineId, -1);
     }
 
 

--- a/app/src/main/java/com/easyfitness/machines/MachineDetailsFragment.java
+++ b/app/src/main/java/com/easyfitness/machines/MachineDetailsFragment.java
@@ -429,7 +429,7 @@ public class MachineDetailsFragment extends Fragment {
                 DAOProfile mDbProfil = new DAOProfile(getContext());
                 Profile lProfile = mDbProfil.getProfile(machineProfilIdArg);
                 // Recupere tous les records de la machine courante
-                List<Record> listRecords = lDbRecord.getAllRecordByMachineIdArray(lProfile, initialMachine.getId());
+                List<Record> listRecords = lDbRecord.getAllRecordByMachineIdArray(initialMachine.getId());
                 for (Record record : listRecords) {
                     record.setExercise(lMachineName); // Change avec le nouveau nom (DEPRECATED)
                     lDbRecord.updateRecord(record); // met a jour


### PR DESCRIPTION
Hello,

This pull request should fix #265.

Bug:
The `DAORecord#getAllRecordByMachine` function was used by the exercise renaming code to find all records to rename. As the function had a required Profile parameter it could never target template records.

Fix:
I decided to remove the Profile parameter from the function.

Thanks
