### PR TITLE
Fix activity startup race condition

### DIFF
--- a/app/src/main/java/com/easyfitness/MainActivity.java
+++ b/app/src/main/java/com/easyfitness/MainActivity.java
@@ -645,6 +645,7 @@ public class MainActivity extends AppCompatActivity {
                     }
 
                     mIntro014Launched = false; // redisplay the intro
+                    savePreferences(); // saving immediatly to prevent a race condition with another instance of this activity
 
                     dialog.dismiss(); // Close the dialog
                     finish(); // Close app
@@ -846,6 +847,9 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onStop() {
         super.onStop();
+
+        //This shouldn't be relied on. When this condition is finishing another activity can read the preferences before this saves the final state.
+        //TODO search and remove code that still relies on this saving the preferences
         savePreferences();
     }
 


### PR DESCRIPTION
Hello,

This pr fixes a race condition. The database deletion code relied on MainActivity.onStart() to save the intro preference it reset. But another MainActivity could start in the meantime and read the outdated preferences causing a softlock.

Thanks